### PR TITLE
Fix admin onboarding type actions

### DIFF
--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -139,6 +139,53 @@ class AdminController extends AbstractController
         ]);
     }
 
+    #[Route('/onboarding-type/{id}', name: 'app_admin_onboarding_type_show')]
+    public function showOnboardingType(OnboardingType $onboardingType): Response
+    {
+        return $this->render('admin/onboarding_type_show.html.twig', [
+            'onboardingType' => $onboardingType,
+        ]);
+    }
+
+    #[Route('/onboarding-type/{id}/edit', name: 'app_admin_onboarding_type_edit')]
+    public function editOnboardingType(Request $request, OnboardingType $onboardingType, EntityManagerInterface $entityManager): Response
+    {
+        if ($request->isMethod('POST')) {
+            $onboardingType->setName($request->request->get('name'));
+            $onboardingType->setDescription($request->request->get('description'));
+
+            $baseTypeId = $request->request->get('baseType');
+            $baseType = null;
+            if ($baseTypeId) {
+                $baseType = $entityManager->getRepository(BaseType::class)->find($baseTypeId);
+            }
+            $onboardingType->setBaseType($baseType);
+            $onboardingType->setUpdatedAt(new \DateTimeImmutable());
+
+            $entityManager->flush();
+
+            $this->addFlash('success', 'OnboardingType wurde erfolgreich aktualisiert!');
+            return $this->redirectToRoute('app_admin_onboarding_types');
+        }
+
+        $baseTypes = $entityManager->getRepository(BaseType::class)->findAll();
+
+        return $this->render('admin/onboarding_type_form.html.twig', [
+            'onboardingType' => $onboardingType,
+            'baseTypes' => $baseTypes,
+        ]);
+    }
+
+    #[Route('/onboarding-type/{id}/delete', name: 'app_admin_onboarding_type_delete')]
+    public function deleteOnboardingType(OnboardingType $onboardingType, EntityManagerInterface $entityManager): Response
+    {
+        $entityManager->remove($onboardingType);
+        $entityManager->flush();
+
+        $this->addFlash('success', 'OnboardingType wurde erfolgreich gelöscht!');
+        return $this->redirectToRoute('app_admin_onboarding_types');
+    }
+
     #[Route('/admin/task-blocks/new', name: 'app_admin_new_task_block', methods: ['GET', 'POST'])]
     public function newTaskBlock(Request $request, EntityManagerInterface $entityManager): Response
     {

--- a/templates/admin/onboarding_type_form.html.twig
+++ b/templates/admin/onboarding_type_form.html.twig
@@ -1,12 +1,15 @@
 {% extends 'base_clean.html.twig' %}
 
-{% block title %}Neuer OnboardingType - Administration - {{ parent() }}{% endblock %}
+{% set edit = onboardingType is defined %}
+{% block title %}{{ edit ? 'OnboardingType bearbeiten' : 'Neuer OnboardingType' }} - Administration - {{ parent() }}{% endblock %}
 
 {% block body %}
 <div class="d-flex justify-content-between align-items-center mb-4">
     <div>
-        <h1><i class="bi bi-collection me-2"></i>Neuer OnboardingType</h1>
-        <p class="text-muted mb-0">Erstellen Sie einen neuen OnboardingType basierend auf einem BaseType</p>
+        <h1><i class="bi bi-collection me-2"></i>{{ edit ? 'OnboardingType bearbeiten' : 'Neuer OnboardingType' }}</h1>
+        <p class="text-muted mb-0">
+            {{ edit ? 'Bearbeiten Sie einen bestehenden OnboardingType' : 'Erstellen Sie einen neuen OnboardingType basierend auf einem BaseType' }}
+        </p>
     </div>
     <a href="{{ path('app_admin_onboarding_types') }}" class="btn btn-outline-secondary">
         <i class="bi bi-arrow-left me-1"></i>Zurück zur Übersicht
@@ -24,7 +27,7 @@
                 
                 <div class="mb-3">
                     <label for="name" class="form-label">Name</label>
-                    <input type="text" class="form-control" id="name" name="name" placeholder="Geben Sie den Namen des OnboardingTypes ein..." required>
+                    <input type="text" class="form-control" id="name" name="name" value="{{ onboardingType.name ?? '' }}" placeholder="Geben Sie den Namen des OnboardingTypes ein..." required>
                     <div class="form-text">
                         Der Name des OnboardingTypes, z.B. "Software Developer Onboarding" oder "HR Mitarbeiter"
                     </div>
@@ -35,7 +38,7 @@
                     <select class="form-select" id="baseType" name="baseType">
                         <option value="">Kein BaseType (optional)</option>
                         {% for baseType in baseTypes %}
-                            <option value="{{ baseType.id }}">{{ baseType.name }}</option>
+                            <option value="{{ baseType.id }}" {% if onboardingType.baseType is defined and onboardingType.baseType and baseType.id == onboardingType.baseType.id %}selected{% endif %}>{{ baseType.name }}</option>
                         {% endfor %}
                     </select>
                     <div class="form-text">
@@ -45,7 +48,7 @@
 
                 <div class="mb-3">
                     <label for="description" class="form-label">Beschreibung</label>
-                    <textarea class="form-control" id="description" name="description" rows="4" placeholder="Beschreiben Sie den Zweck und Inhalt dieses OnboardingTypes..."></textarea>
+                    <textarea class="form-control" id="description" name="description" rows="4" placeholder="Beschreiben Sie den Zweck und Inhalt dieses OnboardingTypes...">{{ onboardingType.description ?? '' }}</textarea>
                     <div class="form-text">
                         Eine detaillierte Beschreibung des OnboardingTypes und wofür er verwendet wird
                     </div>
@@ -53,7 +56,7 @@
 
                 <div class="d-flex justify-content-between">
                     <button type="submit" class="btn btn-primary">
-                        <i class="bi bi-check-circle me-1"></i>OnboardingType erstellen
+                        <i class="bi bi-check-circle me-1"></i>{{ edit ? 'OnboardingType speichern' : 'OnboardingType erstellen' }}
                     </button>
                     <a href="{{ path('app_admin_onboarding_types') }}" class="btn btn-outline-secondary">
                         <i class="bi bi-x-circle me-1"></i>Abbrechen

--- a/templates/admin/onboarding_type_show.html.twig
+++ b/templates/admin/onboarding_type_show.html.twig
@@ -1,0 +1,47 @@
+{% extends 'base_clean.html.twig' %}
+
+{% block title %}OnboardingType {{ onboardingType.name }} - Administration - {{ parent() }}{% endblock %}
+
+{% block body %}
+<div class="d-flex justify-content-between align-items-center mb-4">
+    <div>
+        <h1><i class="bi bi-collection me-2"></i>{{ onboardingType.name }}</h1>
+        <p class="text-muted mb-0">Details des OnboardingTypes</p>
+    </div>
+    <a href="{{ path('app_admin_onboarding_types') }}" class="btn btn-outline-secondary">
+        <i class="bi bi-arrow-left me-1"></i>Zurück zur Übersicht
+    </a>
+</div>
+
+<div class="card">
+    <div class="card-body">
+        <dl class="row mb-4">
+            <dt class="col-sm-3">ID</dt>
+            <dd class="col-sm-9">{{ onboardingType.id }}</dd>
+
+            <dt class="col-sm-3">BaseType</dt>
+            <dd class="col-sm-9">
+                {% if onboardingType.baseType %}
+                    {{ onboardingType.baseType.name }}
+                {% else %}
+                    <span class="text-muted">Kein BaseType</span>
+                {% endif %}
+            </dd>
+
+            <dt class="col-sm-3">Beschreibung</dt>
+            <dd class="col-sm-9">{{ onboardingType.description ?? '-' }}</dd>
+
+            <dt class="col-sm-3">Erstellt</dt>
+            <dd class="col-sm-9">{{ onboardingType.createdAt|date('d.m.Y H:i') }}</dd>
+        </dl>
+        <div class="d-flex justify-content-end">
+            <a href="{{ path('app_admin_onboarding_type_edit', {'id': onboardingType.id}) }}" class="btn btn-warning me-2">
+                <i class="bi bi-pencil"></i> Bearbeiten
+            </a>
+            <a href="{{ path('app_admin_onboarding_type_delete', {'id': onboardingType.id}) }}" class="btn btn-danger" onclick="return confirm('Wirklich löschen?');">
+                <i class="bi bi-trash"></i> Löschen
+            </a>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/templates/admin/onboarding_types.html.twig
+++ b/templates/admin/onboarding_types.html.twig
@@ -58,13 +58,13 @@
                                 </td>
                                 <td>
                                     <div class="btn-group btn-group-sm">
-                                        <a href="#" class="btn btn-outline-primary">
+                                        <a href="{{ path('app_admin_onboarding_type_show', {'id': onboardingType.id}) }}" class="btn btn-outline-primary">
                                             <i class="bi bi-eye"></i>
                                         </a>
-                                        <a href="#" class="btn btn-outline-warning">
+                                        <a href="{{ path('app_admin_onboarding_type_edit', {'id': onboardingType.id}) }}" class="btn btn-outline-warning">
                                             <i class="bi bi-pencil"></i>
                                         </a>
-                                        <a href="#" class="btn btn-outline-danger">
+                                        <a href="{{ path('app_admin_onboarding_type_delete', {'id': onboardingType.id}) }}" class="btn btn-outline-danger" onclick="return confirm('Wirklich l\u00f6schen?');">
                                             <i class="bi bi-trash"></i>
                                         </a>
                                     </div>


### PR DESCRIPTION
## Summary
- add show, edit and delete admin routes for onboarding types
- enhance onboarding type form for editing
- add details template for onboarding types
- wire up action buttons on onboarding type table

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68821fc827408331b77b6bdb1fc4354c