### PR TITLE
Fix BaseType action buttons

### DIFF
--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -89,6 +89,43 @@ class AdminController extends AbstractController
         return $this->render('admin/base_type_form.html.twig');
     }
 
+    #[Route('/base-type/{id}', name: 'app_admin_base_type_show')]
+    public function showBaseType(BaseType $baseType): Response
+    {
+        return $this->render('admin/base_type_show.html.twig', [
+            'baseType' => $baseType,
+        ]);
+    }
+
+    #[Route('/base-type/{id}/edit', name: 'app_admin_base_type_edit')]
+    public function editBaseType(Request $request, BaseType $baseType, EntityManagerInterface $entityManager): Response
+    {
+        if ($request->isMethod('POST')) {
+            $baseType->setName($request->request->get('name'));
+            $baseType->setDescription($request->request->get('description'));
+            $baseType->setUpdatedAt(new \DateTimeImmutable());
+
+            $entityManager->flush();
+
+            $this->addFlash('success', 'BaseType wurde erfolgreich aktualisiert!');
+            return $this->redirectToRoute('app_admin_base_types');
+        }
+
+        return $this->render('admin/base_type_form.html.twig', [
+            'baseType' => $baseType,
+        ]);
+    }
+
+    #[Route('/base-type/{id}/delete', name: 'app_admin_base_type_delete')]
+    public function deleteBaseType(BaseType $baseType, EntityManagerInterface $entityManager): Response
+    {
+        $entityManager->remove($baseType);
+        $entityManager->flush();
+
+        $this->addFlash('success', 'BaseType wurde erfolgreich gel\u00f6scht!');
+        return $this->redirectToRoute('app_admin_base_types');
+    }
+
     #[Route('/role/new', name: 'app_admin_role_new')]
     public function newRole(Request $request, EntityManagerInterface $entityManager): Response
     {

--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -101,8 +101,28 @@ class AdminController extends AbstractController
     public function editBaseType(Request $request, BaseType $baseType, EntityManagerInterface $entityManager): Response
     {
         if ($request->isMethod('POST')) {
-            $baseType->setName($request->request->get('name'));
-            $baseType->setDescription($request->request->get('description'));
+            $name = $request->request->get('name');
+            $description = $request->request->get('description');
+
+            // Validate name field
+            if (empty($name)) {
+                $this->addFlash('error', 'Der Name darf nicht leer sein.');
+                return $this->render('admin/base_type_form.html.twig', [
+                    'baseType' => $baseType,
+                ]);
+            }
+
+            // Check for uniqueness
+            $existingBaseType = $entityManager->getRepository(BaseType::class)->findOneBy(['name' => $name]);
+            if ($existingBaseType && $existingBaseType->getId() !== $baseType->getId()) {
+                $this->addFlash('error', 'Der Name muss eindeutig sein.');
+                return $this->render('admin/base_type_form.html.twig', [
+                    'baseType' => $baseType,
+                ]);
+            }
+
+            $baseType->setName($name);
+            $baseType->setDescription($description);
             $baseType->setUpdatedAt(new \DateTimeImmutable());
 
             $entityManager->flush();

--- a/templates/admin/base_type_form.html.twig
+++ b/templates/admin/base_type_form.html.twig
@@ -1,12 +1,15 @@
 {% extends 'base_clean.html.twig' %}
 
-{% block title %}Neuer BaseType - Administration - {{ parent() }}{% endblock %}
+{% set edit = baseType is defined %}
+{% block title %}{{ edit ? 'BaseType bearbeiten' : 'Neuer BaseType' }} - Administration - {{ parent() }}{% endblock %}
 
 {% block body %}
 <div class="d-flex justify-content-between align-items-center mb-4">
     <div>
-        <h1><i class="bi bi-diagram-3 me-2"></i>Neuer BaseType</h1>
-        <p class="text-muted mb-0">Erstellen Sie einen neuen Basis-Typ für Onboarding-Templates</p>
+        <h1><i class="bi bi-diagram-3 me-2"></i>{{ edit ? 'BaseType bearbeiten' : 'Neuer BaseType' }}</h1>
+        <p class="text-muted mb-0">
+            {{ edit ? 'Bearbeiten Sie einen bestehenden BaseType' : 'Erstellen Sie einen neuen Basis-Typ für Onboarding-Templates' }}
+        </p>
     </div>
     <a href="{{ path('app_admin_base_types') }}" class="btn btn-outline-secondary">
         <i class="bi bi-arrow-left me-1"></i>Zurück zur Übersicht
@@ -24,7 +27,7 @@
                 
                 <div class="mb-3">
                     <label for="name" class="form-label">Name</label>
-                    <input type="text" class="form-control" id="name" name="name" placeholder="Geben Sie den Namen des BaseTypes ein..." required>
+                    <input type="text" class="form-control" id="name" name="name" value="{{ baseType.name ?? '' }}" placeholder="Geben Sie den Namen des BaseTypes ein..." required>
                     <div class="form-text">
                         Der Name des BaseTypes, z.B. "Standard Onboarding" oder "IT-Mitarbeiter"
                     </div>
@@ -32,7 +35,7 @@
 
                 <div class="mb-3">
                     <label for="description" class="form-label">Beschreibung</label>
-                    <textarea class="form-control" id="description" name="description" rows="4" placeholder="Beschreiben Sie den Zweck und Inhalt dieses BaseTypes..."></textarea>
+                    <textarea class="form-control" id="description" name="description" rows="4" placeholder="Beschreiben Sie den Zweck und Inhalt dieses BaseTypes...">{{ baseType.description ?? '' }}</textarea>
                     <div class="form-text">
                         Eine detaillierte Beschreibung des BaseTypes und wofür er verwendet wird
                     </div>
@@ -40,7 +43,7 @@
 
                 <div class="d-flex justify-content-between">
                     <button type="submit" class="btn btn-primary">
-                        <i class="bi bi-check-circle me-1"></i>BaseType erstellen
+                        <i class="bi bi-check-circle me-1"></i>{{ edit ? 'BaseType speichern' : 'BaseType erstellen' }}
                     </button>
                     <a href="{{ path('app_admin_base_types') }}" class="btn btn-outline-secondary">
                         <i class="bi bi-x-circle me-1"></i>Abbrechen

--- a/templates/admin/base_type_show.html.twig
+++ b/templates/admin/base_type_show.html.twig
@@ -1,0 +1,77 @@
+{% extends 'base_clean.html.twig' %}
+
+{% block title %}BaseType {{ baseType.name }} - Administration - {{ parent() }}{% endblock %}
+
+{% block body %}
+<div class="d-flex justify-content-between align-items-center mb-4">
+    <div>
+        <h1><i class="bi bi-diagram-3 me-2"></i>{{ baseType.name }}</h1>
+        <p class="text-muted mb-0">Details des BaseTypes</p>
+    </div>
+    <a href="{{ path('app_admin_base_types') }}" class="btn btn-outline-secondary">
+        <i class="bi bi-arrow-left me-1"></i>Zurück zur Übersicht
+    </a>
+</div>
+
+<div class="card">
+    <div class="card-body">
+        <dl class="row mb-4">
+            <dt class="col-sm-3">ID</dt>
+            <dd class="col-sm-9">{{ baseType.id }}</dd>
+            <dt class="col-sm-3">Beschreibung</dt>
+            <dd class="col-sm-9">{{ baseType.description ?? '-' }}</dd>
+            <dt class="col-sm-3">Erstellt</dt>
+            <dd class="col-sm-9">{{ baseType.createdAt|date('d.m.Y H:i') }}</dd>
+        </dl>
+
+        <h5>Zugeordnete Task Blocks</h5>
+        {% if baseType.taskBlocks|length > 0 %}
+            <div class="table-responsive">
+                <table class="table table-sm">
+                    <thead>
+                    <tr>
+                        <th>Name</th>
+                        <th>Beschreibung</th>
+                        <th>Tasks</th>
+                        <th>Reihenfolge</th>
+                        <th>Aktionen</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    {% for taskBlock in baseType.taskBlocks|sort((a, b) => a.sortOrder <=> b.sortOrder) %}
+                        <tr>
+                            <td><strong>{{ taskBlock.name }}</strong></td>
+                            <td>{{ taskBlock.description|slice(0,50) }}{% if taskBlock.description|length > 50 %}...{% endif %}</td>
+                            <td>
+                                {% if taskBlock.tasks|length > 0 %}
+                                    <span class="badge bg-success">{{ taskBlock.tasks|length }}</span>
+                                {% else %}
+                                    <span class="text-muted">0</span>
+                                {% endif %}
+                            </td>
+                            <td><span class="badge bg-secondary">{{ taskBlock.sortOrder }}</span></td>
+                            <td>
+                                <a href="{{ path('app_admin_task_block_show', {'id': taskBlock.id}) }}" class="btn btn-sm btn-outline-primary">
+                                    <i class="bi bi-eye"></i>
+                                </a>
+                            </td>
+                        </tr>
+                    {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        {% else %}
+            <p class="text-muted">Diesem BaseType sind noch keine Task Blocks zugeordnet.</p>
+        {% endif %}
+
+        <div class="d-flex justify-content-end">
+            <a href="{{ path('app_admin_base_type_edit', {'id': baseType.id}) }}" class="btn btn-warning me-2">
+                <i class="bi bi-pencil"></i> Bearbeiten
+            </a>
+            <a href="{{ path('app_admin_base_type_delete', {'id': baseType.id}) }}" class="btn btn-danger" onclick="return confirm('Wirklich löschen?');">
+                <i class="bi bi-trash"></i> Löschen
+            </a>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/templates/admin/base_types.html.twig
+++ b/templates/admin/base_types.html.twig
@@ -50,13 +50,13 @@
                                 </td>
                                 <td>
                                     <div class="btn-group btn-group-sm">
-                                        <a href="#" class="btn btn-outline-primary">
+                                        <a href="{{ path('app_admin_base_type_show', {'id': baseType.id}) }}" class="btn btn-outline-primary" title="Anzeigen">
                                             <i class="bi bi-eye"></i>
                                         </a>
-                                        <a href="#" class="btn btn-outline-warning">
+                                        <a href="{{ path('app_admin_base_type_edit', {'id': baseType.id}) }}" class="btn btn-outline-warning" title="Bearbeiten">
                                             <i class="bi bi-pencil"></i>
                                         </a>
-                                        <a href="#" class="btn btn-outline-danger">
+                                        <a href="{{ path('app_admin_base_type_delete', {'id': baseType.id}) }}" class="btn btn-outline-danger" onclick="return confirm('Wirklich l\u00f6schen?');" title="Löschen">
                                             <i class="bi bi-trash"></i>
                                         </a>
                                     </div>


### PR DESCRIPTION
## Summary
- add CRUD views for BaseType
- link BaseType actions to new routes

## Testing
- `composer install --no-interaction` *(fails: CONNECT tunnel failed for cdn.jsdelivr.net)*
- `./vendor/bin/phpunit -c phpunit.dist.xml`

------
https://chatgpt.com/codex/tasks/task_e_68826fd1515083319f86fc91e3cb702b