### PR TITLE
Remove fixed task due date

### DIFF
--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -312,17 +312,15 @@ class AdminController extends AbstractController
             
             // Fälligkeit konfigurieren
             $dueDateType = $request->request->get('dueDateType');
-            if ($dueDateType === 'fixed') {
-                $dueDate = $request->request->get('dueDate');
-                if ($dueDate) {
-                    $task->setDueDate(new \DateTimeImmutable($dueDate));
-                }
-            } elseif ($dueDateType === 'relative') {
+            if ($dueDateType === 'relative') {
                 $dueDays = $request->request->get('dueDaysFromEntry');
                 if ($dueDays !== null && $dueDays !== '') {
                     $task->setDueDaysFromEntry((int)$dueDays);
                 }
+            } else {
+                $task->setDueDaysFromEntry(null);
             }
+            $task->setDueDate(null);
             
             // Zuständigkeit
             $assignedEmail = $request->request->get('assignedEmail');
@@ -378,22 +376,17 @@ class AdminController extends AbstractController
             
             // Fälligkeit konfigurieren
             $dueDateType = $request->request->get('dueDateType');
-            if ($dueDateType === 'fixed') {
-                $dueDate = $request->request->get('dueDate');
-                if ($dueDate) {
-                    $task->setDueDate(new \DateTimeImmutable($dueDate));
-                    $task->setDueDaysFromEntry(null);
-                }
-            } elseif ($dueDateType === 'relative') {
+            if ($dueDateType === 'relative') {
                 $dueDays = $request->request->get('dueDaysFromEntry');
                 if ($dueDays !== null && $dueDays !== '') {
                     $task->setDueDaysFromEntry((int)$dueDays);
-                    $task->setDueDate(null);
+                } else {
+                    $task->setDueDaysFromEntry(null);
                 }
             } else {
-                $task->setDueDate(null);
                 $task->setDueDaysFromEntry(null);
             }
+            $task->setDueDate(null);
             
             // Zuständigkeit zurücksetzen
             $task->setAssignedEmail(null);

--- a/templates/admin/task_form.html.twig
+++ b/templates/admin/task_form.html.twig
@@ -43,37 +43,24 @@
                         <div class="mb-3">
                             <label class="form-label">Fälligkeitstyp</label>
                             <div class="form-check">
-                                <input class="form-check-input" type="radio" name="dueDateType" id="dueDateTypeNone" value="none" 
-                                       {% if not task or (not task.dueDate and task.dueDaysFromEntry is null) %}checked{% endif %}>
+                                <input class="form-check-input" type="radio" name="dueDateType" id="dueDateTypeNone" value="none"
+                                       {% if task and (not task.dueDate and task.dueDaysFromEntry is null) %}checked{% endif %}>
                                 <label class="form-check-label" for="dueDateTypeNone">
                                     Kein Fälligkeitsdatum
                                 </label>
                             </div>
                             <div class="form-check">
-                                <input class="form-check-input" type="radio" name="dueDateType" id="dueDateTypeFixed" value="fixed" 
-                                       {% if task and task.dueDate %}checked{% endif %}>
-                                <label class="form-check-label" for="dueDateTypeFixed">
-                                    Festes Datum
-                                </label>
-                            </div>
-                            <div class="form-check">
-                                <input class="form-check-input" type="radio" name="dueDateType" id="dueDateTypeRelative" value="relative" 
-                                       {% if task and task.dueDaysFromEntry is not null %}checked{% endif %}>
+                                <input class="form-check-input" type="radio" name="dueDateType" id="dueDateTypeRelative" value="relative"
+                                       {% if not task or (task.dueDaysFromEntry is not null) %}checked{% endif %}>
                                 <label class="form-check-label" for="dueDateTypeRelative">
                                     Relativ zum Eintrittsdatum
                                 </label>
                             </div>
                         </div>
                         
-                        <div class="mb-3" id="fixedDateGroup" style="display: none;">
-                            <label for="dueDate" class="form-label">Fälligkeitsdatum</label>
-                            <input type="date" class="form-control" id="dueDate" name="dueDate" 
-                                   value="{{ task and task.dueDate ? task.dueDate.format('Y-m-d') : '' }}">
-                        </div>
-                        
                         <div class="mb-3" id="relativeDateGroup" style="display: none;">
                             <label for="dueDaysFromEntry" class="form-label">Tage vor/nach Eintrittsdatum</label>
-                            <input type="number" class="form-control" id="dueDaysFromEntry" name="dueDaysFromEntry" 
+                            <input type="number" class="form-control" id="dueDaysFromEntry" name="dueDaysFromEntry"
                                    value="{{ task ? task.dueDaysFromEntry : '' }}">
                             <div class="form-text">Negative Werte = vor Eintrittsdatum, positive Werte = nach Eintrittsdatum. Beispiel: -5 = 5 Tage vor Eintritt.</div>
                         </div>
@@ -153,12 +140,10 @@
 document.addEventListener('DOMContentLoaded', function() {
     // Fälligkeit Type Toggle
     const dueDateRadios = document.querySelectorAll('input[name="dueDateType"]');
-    const fixedDateGroup = document.getElementById('fixedDateGroup');
     const relativeDateGroup = document.getElementById('relativeDateGroup');
     
     function toggleDueDateGroups() {
         const selectedType = document.querySelector('input[name="dueDateType"]:checked').value;
-        fixedDateGroup.style.display = selectedType === 'fixed' ? 'block' : 'none';
         relativeDateGroup.style.display = selectedType === 'relative' ? 'block' : 'none';
     }
     


### PR DESCRIPTION
## Summary
- remove fixed date option from task form
- simplify controller logic for due dates

## Testing
- `composer install --no-interaction --no-scripts`
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68827100b40c83318837d939655a36b7