### PR TITLE
Remove top stats blocks

### DIFF
--- a/src/Controller/DashboardController.php
+++ b/src/Controller/DashboardController.php
@@ -52,8 +52,6 @@ class DashboardController extends AbstractController
             'active_onboardings' => $this->getActiveOnboardings($entityManager),
             'open_tasks' => $this->getOpenTasks($entityManager),
             'overdue_tasks' => count($this->getOverdueTasks($entityManager)),
-            'total_types' => $this->getTotalOnboardingTypes($entityManager),
-            'total_base_types' => $this->getTotalBaseTypes($entityManager),
         ];
     }
 
@@ -117,27 +115,4 @@ class DashboardController extends AbstractController
             ->getResult();
     }
 
-    /**
-     * Gesamtzahl der OnboardingTypes.
-     */
-    private function getTotalOnboardingTypes(EntityManagerInterface $entityManager): int
-    {
-        return $entityManager->getRepository(OnboardingType::class)
-            ->createQueryBuilder('ot')
-            ->select('COUNT(ot.id)')
-            ->getQuery()
-            ->getSingleScalarResult();
-    }
-
-    /**
-     * Gesamtzahl der BaseTypes.
-     */
-    private function getTotalBaseTypes(EntityManagerInterface $entityManager): int
-    {
-        return $entityManager->getRepository(BaseType::class)
-            ->createQueryBuilder('bt')
-            ->select('COUNT(bt.id)')
-            ->getQuery()
-            ->getSingleScalarResult();
-    }
 }

--- a/templates/dashboard/index.html.twig
+++ b/templates/dashboard/index.html.twig
@@ -13,54 +13,7 @@
     </div>
 </div>
 
-{# Statistik-Karten #}
-<div class="row mb-4">
-    <div class="col-md-4">
-        <div class="card bg-primary text-white">
-            <div class="card-body">
-                <div class="d-flex justify-content-between">
-                    <div>
-                        <h5 class="card-title">Aktive Onboardings</h5>
-                        <h2 class="mb-0">{{ stats.total_onboardings }}</h2>
-                    </div>
-                    <div class="align-self-center">
-                        <i class="bi bi-people-fill fs-1"></i>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </div>
-    <div class="col-md-4">
-        <div class="card bg-success text-white">
-            <div class="card-body">
-                <div class="d-flex justify-content-between">
-                    <div>
-                        <h5 class="card-title">Onboarding-Typen</h5>
-                        <h2 class="mb-0">{{ stats.total_types }}</h2>
-                    </div>
-                    <div class="align-self-center">
-                        <i class="bi bi-collection-fill fs-1"></i>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </div>
-    <div class="col-md-4">
-        <div class="card bg-info text-white">
-            <div class="card-body">
-                <div class="d-flex justify-content-between">
-                    <div>
-                        <h5 class="card-title">Basis-Typen</h5>
-                        <h2 class="mb-0">{{ stats.total_base_types }}</h2>
-                    </div>
-                    <div class="align-self-center">
-                        <i class="bi bi-diagram-3-fill fs-1"></i>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </div>
-</div>
+
 
 {# Aktuelle Onboardings #}
 <div class="row">
@@ -69,6 +22,7 @@
             <div class="card-header d-flex justify-content-between align-items-center">
                 <h5 class="mb-0">
                     <i class="bi bi-person-check me-2"></i>Neueste Onboardings
+                    <span class="small text-muted">(aktive Onboardings: {{ stats.active_onboardings }})</span>
                 </h5>
                 <a href="{{ path('app_onboarding_new') }}" class="btn btn-primary btn-sm">
                     <i class="bi bi-plus-circle me-1"></i>Neues Onboarding


### PR DESCRIPTION
## Summary
- drop header stats cards from dashboard
- show active onboarding count next to heading
- remove unused stats functions

## Testing
- `composer install --no-interaction --no-scripts`
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6882a29587d88331b60415f6db33e677