### PR TITLE
Enable file upload and download for task email templates

### DIFF
--- a/src/Controller/Admin/OnboardingAdminController.php
+++ b/src/Controller/Admin/OnboardingAdminController.php
@@ -197,4 +197,24 @@ class OnboardingAdminController extends AbstractController
 
         return $this->redirectToRoute('app_admin_task_block_tasks', ['id' => $taskBlock->getId()]);
     }
+
+    #[Route('/task-blocks/{id}/tasks/{taskId}/download-template', name: 'app_admin_task_download_template', requirements: ['id' => '\\d+', 'taskId' => '\\d+'], methods: ['GET'])]
+    public function downloadTemplate(TaskBlock $taskBlock, int $taskId, EntityManagerInterface $entityManager): Response
+    {
+        $task = $entityManager->getRepository(Task::class)->find($taskId);
+        if (!$task || $task->getTaskBlock()->getId() !== $taskBlock->getId()) {
+            throw $this->createNotFoundException('Task not found');
+        }
+
+        $content = $task->getEmailTemplate();
+        if (null === $content) {
+            throw $this->createNotFoundException('Template not found');
+        }
+
+        $response = new Response($content);
+        $response->headers->set('Content-Type', 'text/html');
+        $response->headers->set('Content-Disposition', 'attachment; filename="email-template-' . $task->getId() . '.html"');
+
+        return $response;
+    }
 }

--- a/src/Service/TaskService.php
+++ b/src/Service/TaskService.php
@@ -133,7 +133,12 @@ class TaskService
 
         $sendEmail = $request->request->get('sendEmail');
         if ($sendEmail) {
-            $task->setEmailTemplate($request->request->get('emailTemplate'));
+            $template = $request->request->get('emailTemplate');
+            $uploadedFile = $request->files->get('emailTemplateFile');
+            if ($uploadedFile && $uploadedFile->isValid()) {
+                $template = file_get_contents($uploadedFile->getPathname());
+            }
+            $task->setEmailTemplate($template);
         } else {
             $task->setEmailTemplate(null);
         }

--- a/templates/admin/task_form.html.twig
+++ b/templates/admin/task_form.html.twig
@@ -7,7 +7,7 @@
     <h1>{% if task %}Task bearbeiten{% else %}Neue Task erstellen{% endif %}</h1>
     <p class="text-muted">TaskBlock: {{ taskBlock.name }}</p>
     
-    <form method="post">
+    <form method="post" enctype="multipart/form-data">
         <div class="row">
             <div class="col-md-8">
                 <!-- Grunddaten -->
@@ -127,9 +127,19 @@
                         </div>
                         
                         <div class="mb-3" id="emailTemplateGroup" style="display: none;">
-                            <label for="emailTemplate" class="form-label">E-Mail-Template</label>
+                            <label for="emailTemplateFile" class="form-label">HTML-Datei hochladen</label>
+                            <input class="form-control" type="file" id="emailTemplateFile" name="emailTemplateFile" accept=".html,text/html">
+                            <div class="form-text">Optional kann das Template als Datei hochgeladen werden.</div>
+
+                            <label for="emailTemplate" class="form-label mt-3">E-Mail-Template</label>
                             <textarea class="form-control" id="emailTemplate" name="emailTemplate" rows="4" placeholder="HTML-Template für die E-Mail...">{{ task ? task.emailTemplate : '' }}</textarea>
                             <div class="form-text">Verwenden Sie Variablen wie {{ '{{firstName}}' }}, {{ '{{lastName}}' }}, {{ '{{entryDate}}' }}, {{ '{{manager}}' }}, {{ '{{buddy}}' }}.</div>
+
+                            {% if task and task.emailTemplate %}
+                                <a href="{{ path('app_admin_task_download_template', {'id': taskBlock.id, 'taskId': task.id}) }}" class="btn btn-outline-secondary btn-sm mt-2">
+                                    <i class="bi bi-download"></i> Aktuelles Template herunterladen
+                                </a>
+                            {% endif %}
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- allow uploading a file for the email template when editing a task
- expose route to download the current task email template
- update form to support file uploads and download link

## Testing
- `composer install` *(fails: cdn.jsdelivr.net blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6882a3d89a4c8331b98406182b806bf8