### PR TITLE
Add authentication with user management

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -1,17 +1,23 @@
 security:
-    # https://symfony.com/doc/current/security.html#registering-the-user-hashing-passwords
     password_hashers:
-        Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface: 'auto'
-    # https://symfony.com/doc/current/security.html#loading-the-user-the-user-provider
+        App\Entity\User: 'auto'
     providers:
-        users_in_memory: { memory: null }
+        app_user_provider:
+            entity:
+                class: App\Entity\User
+                property: username
     firewalls:
         dev:
             pattern: ^/(_(profiler|wdt)|css|images|js)/
             security: false
         main:
             lazy: true
-            provider: users_in_memory
+            provider: app_user_provider
+            form_login:
+                login_path: app_login
+                check_path: app_login
+            logout:
+                path: app_logout
 
             # activate different ways to authenticate
             # https://symfony.com/doc/current/security.html#the-firewall
@@ -22,8 +28,9 @@ security:
     # Easy way to control access for large sections of your site
     # Note: Only the *first* access control that matches will be used
     access_control:
-        # - { path: ^/admin, roles: ROLE_ADMIN }
-        # - { path: ^/profile, roles: ROLE_USER }
+        - { path: ^/login, roles: PUBLIC_ACCESS }
+        - { path: ^/logout, roles: PUBLIC_ACCESS }
+        - { path: ^/, roles: ROLE_USER }
 
 when@test:
     security:

--- a/src/Command/UserCommand.php
+++ b/src/Command/UserCommand.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Command;
+
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+#[AsCommand('app:user', 'Legt einen Benutzer an oder aktualisiert das Passwort.')]
+class UserCommand extends Command
+{
+    public function __construct(private readonly EntityManagerInterface $em, private readonly UserPasswordHasherInterface $hasher)
+    {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->addArgument('email', InputArgument::REQUIRED, 'E-Mail-Adresse des Benutzers');
+        $this->addArgument('password', InputArgument::REQUIRED, 'Neues Passwort (min 8 Zeichen)');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $email = (string) $input->getArgument('email');
+        $password = (string) $input->getArgument('password');
+
+        if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
+            $output->writeln('<error>Ungültige E-Mail-Adresse.</error>');
+            return Command::FAILURE;
+        }
+
+        if (strlen($password) < 8) {
+            $output->writeln('<error>Passwort muss mindestens 8 Zeichen lang sein.</error>');
+            return Command::FAILURE;
+        }
+
+        $repo = $this->em->getRepository(User::class);
+        $user = $repo->findOneBy(['username' => $email]);
+        $created = false;
+        if (!$user) {
+            $user = new User();
+            $user->setUsername($email);
+            $user->setEmail($email);
+            $user->setRoles(['ROLE_USER']);
+            $created = true;
+        }
+
+        $user->setPassword($this->hasher->hashPassword($user, $password));
+        $this->em->persist($user);
+        $this->em->flush();
+
+        if ($created) {
+            $output->writeln('<info>Benutzer wurde erstellt.</info>');
+        } else {
+            $output->writeln('<info>Passwort wurde aktualisiert.</info>');
+        }
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Controller/Admin/SettingsController.php
+++ b/src/Controller/Admin/SettingsController.php
@@ -6,6 +6,7 @@ use App\Entity\BaseType;
 use App\Entity\OnboardingType;
 use App\Entity\Role;
 use App\Entity\TaskBlock;
+use App\Entity\User;
 use App\Service\AdminLookupService;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -31,6 +32,7 @@ class SettingsController extends AbstractController
             'onboardingTypes' => $entityManager->getRepository(OnboardingType::class)->count([]),
             'roles' => $entityManager->getRepository(Role::class)->count([]),
             'taskBlocks' => $entityManager->getRepository(TaskBlock::class)->count([]),
+            'users' => $entityManager->getRepository(User::class)->count([]),
         ];
 
         return $this->render('admin/index.html.twig', [

--- a/src/Controller/Admin/UserController.php
+++ b/src/Controller/Admin/UserController.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace App\Controller\Admin;
+
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+use Symfony\Component\Routing\Attribute\Route;
+
+/**
+ * Verwaltung der Systembenutzer.
+ */
+#[Route('/admin/users')]
+class UserController extends AbstractController
+{
+    #[Route('', name: 'app_admin_users')]
+    public function list(EntityManagerInterface $entityManager): Response
+    {
+        $users = $entityManager->getRepository(User::class)->findAll();
+
+        return $this->render('admin/users.html.twig', [
+            'users' => $users,
+        ]);
+    }
+
+    #[Route('/new', name: 'app_admin_user_new', methods: ['GET', 'POST'])]
+    public function new(Request $request, EntityManagerInterface $entityManager, UserPasswordHasherInterface $hasher): Response
+    {
+        $user = new User();
+
+        if ($request->isMethod('POST')) {
+            $email = (string) $request->request->get('email');
+            $password = (string) $request->request->get('password');
+
+            if (strlen($password) < 8) {
+                $this->addFlash('error', 'Passwort muss mindestens 8 Zeichen haben.');
+            } elseif (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
+                $this->addFlash('error', 'Ungültige E-Mail-Adresse.');
+            } else {
+                $user->setUsername($email);
+                $user->setEmail($email);
+                $user->setRoles(['ROLE_USER']);
+                $user->setPassword($hasher->hashPassword($user, $password));
+
+                $entityManager->persist($user);
+                $entityManager->flush();
+
+                $this->addFlash('success', 'Benutzer wurde erstellt.');
+
+                return $this->redirectToRoute('app_admin_users');
+            }
+        }
+
+        return $this->render('admin/user_form.html.twig', [
+            'user' => $user,
+        ]);
+    }
+
+    #[Route('/{id}', name: 'app_admin_user_edit', requirements: ['id' => '\\d+'], methods: ['GET', 'POST'])]
+    public function edit(User $user, Request $request, EntityManagerInterface $entityManager, UserPasswordHasherInterface $hasher): Response
+    {
+        if ($request->isMethod('POST')) {
+            $email = (string) $request->request->get('email');
+            $password = (string) $request->request->get('password');
+
+            if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
+                $this->addFlash('error', 'Ungültige E-Mail-Adresse.');
+            } elseif ($password !== '' && strlen($password) < 8) {
+                $this->addFlash('error', 'Passwort muss mindestens 8 Zeichen haben.');
+            } else {
+                $user->setUsername($email);
+                $user->setEmail($email);
+                if ($password !== '') {
+                    $user->setPassword($hasher->hashPassword($user, $password));
+                }
+
+                $entityManager->flush();
+
+                $this->addFlash('success', 'Benutzer wurde aktualisiert.');
+
+                return $this->redirectToRoute('app_admin_users');
+            }
+        }
+
+        return $this->render('admin/user_form.html.twig', [
+            'user' => $user,
+        ]);
+    }
+}

--- a/src/Controller/SecurityController.php
+++ b/src/Controller/SecurityController.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Authentication\AuthenticationUtils;
+
+/**
+ * Verantwortlich für Login und Logout.
+ */
+class SecurityController extends AbstractController
+{
+    #[Route('/login', name: 'app_login')]
+    public function login(AuthenticationUtils $authenticationUtils): Response
+    {
+        $error = $authenticationUtils->getLastAuthenticationError();
+        $lastUsername = $authenticationUtils->getLastUsername();
+
+        return $this->render('security/login.html.twig', [
+            'last_username' => $lastUsername,
+            'error' => $error,
+        ]);
+    }
+
+    #[Route('/logout', name: 'app_logout')]
+    public function logout(): void
+    {
+        // Wird von Symfony automatisch behandelt
+    }
+}

--- a/templates/admin/index.html.twig
+++ b/templates/admin/index.html.twig
@@ -53,6 +53,17 @@
             </div>
         </div>
     </div>
+
+    <div class="col-md-3 mt-3 mt-md-0">
+        <div class="card bg-secondary text-white">
+            <div class="card-body text-center">
+                <i class="bi bi-people" style="font-size: 2rem;"></i>
+                <h3>{{ stats.users }}</h3>
+                <p>Benutzer</p>
+                <a href="{{ path('app_admin_users') }}" class="btn btn-light btn-sm">Verwalten</a>
+            </div>
+        </div>
+    </div>
 </div>
 
 <div class="row">
@@ -75,6 +86,9 @@
                             <a href="{{ path('app_admin_onboarding_type_new') }}" class="list-group-item list-group-item-action">
                                 <i class="bi bi-plus-circle"></i> Neuen OnboardingType erstellen
                             </a>
+                            <a href="{{ path('app_admin_user_new') }}" class="list-group-item list-group-item-action">
+                                <i class="bi bi-plus-circle"></i> Neuen Benutzer erstellen
+                            </a>
                         </div>
                     </div>
                     <div class="col-md-6">
@@ -82,6 +96,9 @@
                         <div class="list-group">
                             <a href="{{ path('app_admin_email_settings') }}" class="list-group-item list-group-item-action">
                                 <i class="bi bi-envelope-gear"></i> E-Mail-Einstellungen
+                            </a>
+                            <a href="{{ path('app_admin_users') }}" class="list-group-item list-group-item-action">
+                                <i class="bi bi-people"></i> Benutzer verwalten
                             </a>
                             <a href="#" class="list-group-item list-group-item-action">
                                 <i class="bi bi-file-earmark-text"></i> E-Mail-Templates verwalten

--- a/templates/admin/user_form.html.twig
+++ b/templates/admin/user_form.html.twig
@@ -1,0 +1,33 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}Benutzer verwalten - Administration - {{ parent() }}{% endblock %}
+
+{% block body %}
+<div class="d-flex justify-content-between align-items-center mb-4">
+    <div>
+        <h1><i class="bi bi-person me-2"></i>{{ user.id ? 'Benutzer bearbeiten' : 'Neuer Benutzer' }}</h1>
+    </div>
+    <a href="{{ path('app_admin_users') }}" class="btn btn-outline-secondary">
+        <i class="bi bi-arrow-left me-1"></i>Zurück
+    </a>
+</div>
+
+<div class="card">
+    <div class="card-body">
+        <form method="post">
+            <div class="mb-3">
+                <label for="email" class="form-label">E-Mail-Adresse</label>
+                <input type="email" id="email" name="email" class="form-control" required value="{{ user.email }}">
+            </div>
+            <div class="mb-3">
+                <label for="password" class="form-label">Passwort</label>
+                <input type="password" id="password" name="password" class="form-control" minlength="8" {{ user.id ? '' : 'required' }}>
+                <div class="form-text">Mindestens 8 Zeichen</div>
+            </div>
+            <button type="submit" class="btn btn-primary">
+                <i class="bi bi-check-circle me-1"></i>Speichern
+            </button>
+        </form>
+    </div>
+</div>
+{% endblock %}

--- a/templates/admin/users.html.twig
+++ b/templates/admin/users.html.twig
@@ -1,0 +1,50 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}Benutzer - Administration - {{ parent() }}{% endblock %}
+
+{% block body %}
+<div class="d-flex justify-content-between align-items-center mb-4">
+    <div>
+        <h1><i class="bi bi-people me-2"></i>Benutzer</h1>
+        <p class="text-muted mb-0">Verwalten Sie Systembenutzer</p>
+    </div>
+    <a href="{{ path('app_admin_user_new') }}" class="btn btn-primary">
+        <i class="bi bi-plus-circle me-1"></i>Neuer Benutzer
+    </a>
+</div>
+
+<div class="card">
+    <div class="card-body">
+        {% if users|length > 0 %}
+            <div class="table-responsive">
+                <table class="table table-hover">
+                    <thead>
+                        <tr>
+                            <th>ID</th>
+                            <th>E-Mail</th>
+                            <th>Erstellt</th>
+                            <th>Aktionen</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for user in users %}
+                            <tr>
+                                <td><span class="badge bg-secondary">#{{ user.id }}</span></td>
+                                <td>{{ user.email }}</td>
+                                <td>{{ user.createdAt|date('d.m.Y H:i') }}</td>
+                                <td>
+                                    <a href="{{ path('app_admin_user_edit', {id: user.id}) }}" class="btn btn-sm btn-outline-primary">
+                                        <i class="bi bi-pencil"></i>
+                                    </a>
+                                </td>
+                            </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        {% else %}
+            <p class="text-muted mb-0">Keine Benutzer vorhanden.</p>
+        {% endif %}
+    </div>
+</div>
+{% endblock %}

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -42,6 +42,24 @@
                             </a>
                         </li>
                     </ul>
+                    <ul class="navbar-nav ms-auto">
+                        {% if app.user %}
+                            <li class="nav-item">
+                                <span class="navbar-text me-2">{{ app.user.username }}</span>
+                            </li>
+                            <li class="nav-item">
+                                <a class="nav-link" href="{{ path('app_logout') }}">
+                                    <i class="bi bi-box-arrow-right me-1"></i>Logout
+                                </a>
+                            </li>
+                        {% else %}
+                            <li class="nav-item">
+                                <a class="nav-link" href="{{ path('app_login') }}">
+                                    <i class="bi bi-box-arrow-in-right me-1"></i>Login
+                                </a>
+                            </li>
+                        {% endif %}
+                    </ul>
                 </div>
             </div>
         </nav>

--- a/templates/security/login.html.twig
+++ b/templates/security/login.html.twig
@@ -1,0 +1,23 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}Login - {{ parent() }}{% endblock %}
+
+{% block body %}
+<h1 class="mb-4">Login</h1>
+{% if error %}
+    <div class="alert alert-danger">Ungültige Anmeldedaten.</div>
+{% endif %}
+<form method="post">
+    <div class="mb-3">
+        <label for="username" class="form-label">E-Mail-Adresse</label>
+        <input type="email" id="username" name="_username" class="form-control" required value="{{ last_username }}">
+    </div>
+    <div class="mb-3">
+        <label for="password" class="form-label">Passwort</label>
+        <input type="password" id="password" name="_password" class="form-control" required minlength="8">
+    </div>
+    <button type="submit" class="btn btn-primary">
+        <i class="bi bi-box-arrow-in-right me-1"></i>Login
+    </button>
+</form>
+{% endblock %}


### PR DESCRIPTION
## Summary
- configure security to use database users and login form
- add login/logout controller and template
- add admin UI to manage users
- provide console command for creating users or changing passwords
- show login/logout links in navbar and link to new admin sections

## Testing
- `composer install --no-interaction --no-scripts`
- `./vendor/bin/phpunit -c phpunit.dist.xml --colors=never`

------
https://chatgpt.com/codex/tasks/task_e_6883325b68a883319b3804a6146c707b