### PR TITLE
Add command to send due emails

### DIFF
--- a/src/Command/SendDueEmailsCommand.php
+++ b/src/Command/SendDueEmailsCommand.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace App\\Command;
+namespace App\Command;
 
-use App\\Entity\\OnboardingTask;
-use App\\Service\\EmailService;
-use Doctrine\\ORM\\EntityManagerInterface;
-use Symfony\\Component\\Console\\Attribute\\AsCommand;
-use Symfony\\Component\\Console\\Command\\Command;
-use Symfony\\Component\\Console\\Input\\InputInterface;
-use Symfony\\Component\\Console\\Output\\OutputInterface;
+use App\Entity\OnboardingTask;
+use App\Service\EmailService;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
 
 #[AsCommand('app:send-due-emails', 'Versendet alle heute fälligen Aufgaben-E-Mails.')]
 class SendDueEmailsCommand extends Command
@@ -24,7 +24,7 @@ class SendDueEmailsCommand extends Command
     {
         $today = new \DateTimeImmutable('today');
 
-        /** @var \App\\Repository\\OnboardingTaskRepository $repo */
+        /** @var \App\Repository\OnboardingTaskRepository $repo */
         $repo = $this->entityManager->getRepository(OnboardingTask::class);
         $tasks = $repo->findTasksDueForDate($today);
 

--- a/src/Command/SendDueEmailsCommand.php
+++ b/src/Command/SendDueEmailsCommand.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\\Command;
+
+use App\\Entity\\OnboardingTask;
+use App\\Service\\EmailService;
+use Doctrine\\ORM\\EntityManagerInterface;
+use Symfony\\Component\\Console\\Attribute\\AsCommand;
+use Symfony\\Component\\Console\\Command\\Command;
+use Symfony\\Component\\Console\\Input\\InputInterface;
+use Symfony\\Component\\Console\\Output\\OutputInterface;
+
+#[AsCommand('app:send-due-emails', 'Versendet alle heute fälligen Aufgaben-E-Mails.')]
+class SendDueEmailsCommand extends Command
+{
+    public function __construct(
+        private readonly EntityManagerInterface $entityManager,
+        private readonly EmailService $emailService
+    ) {
+        parent::__construct();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $today = new \DateTimeImmutable('today');
+
+        /** @var \App\\Repository\\OnboardingTaskRepository $repo */
+        $repo = $this->entityManager->getRepository(OnboardingTask::class);
+        $tasks = $repo->findTasksDueForDate($today);
+
+        foreach ($tasks as $task) {
+            /* @var OnboardingTask $task */
+            $recipient = $task->getFinalAssignedEmail();
+            if (null === $recipient) {
+                continue;
+            }
+
+            try {
+                $this->emailService->sendEmail(
+                    $recipient,
+                    'Aufgabe fällig: ' . $task->getTitle(),
+                    $task->getEmailTemplate() ?? ''
+                );
+                $task->setEmailSentAt(new \DateTimeImmutable());
+            } catch (\Throwable $e) {
+                $output->writeln('<error>' . $e->getMessage() . '</error>');
+            }
+        }
+
+        $this->entityManager->flush();
+        $output->writeln(sprintf('<info>%d E-Mails verarbeitet.</info>', count($tasks)));
+
+        return Command::SUCCESS;
+    }
+}
+

--- a/src/Entity/OnboardingTask.php
+++ b/src/Entity/OnboardingTask.php
@@ -192,6 +192,18 @@ class OnboardingTask
         return $this;
     }
 
+    /**
+     * Gibt die finale E-Mail-Adresse zurück (direkte Eingabe oder aus Rolle).
+     */
+    public function getFinalAssignedEmail(): ?string
+    {
+        if ($this->assignedEmail) {
+            return $this->assignedEmail;
+        }
+
+        return $this->assignedRole ? $this->assignedRole->getEmail() : null;
+    }
+
     public function isSendEmail(): bool
     {
         return $this->sendEmail;

--- a/src/Repository/OnboardingTaskRepository.php
+++ b/src/Repository/OnboardingTaskRepository.php
@@ -66,6 +66,7 @@ class OnboardingTaskRepository extends ServiceEntityRepository
 
     /**
      * Findet alle Tasks, deren E-Mail heute versendet werden soll.
+     * Berücksichtigt sowohl heute fällige als auch überfällige Tasks, die noch nicht versendet wurden.
      */
     public function findTasksDueForDate(\DateTimeImmutable $date): array
     {
@@ -78,10 +79,9 @@ class OnboardingTaskRepository extends ServiceEntityRepository
             ->andWhere('ot.emailTemplate IS NOT NULL')
             ->andWhere('ot.emailSentAt IS NULL')
             ->andWhere('(
-                (ot.dueDate >= :start AND ot.dueDate < :end) OR
-                (ot.dueDate IS NULL AND ot.dueDaysFromEntry IS NOT NULL AND DATE_ADD(o.entryDate, ot.dueDaysFromEntry, \'DAY\') >= :start AND DATE_ADD(o.entryDate, ot.dueDaysFromEntry, \'DAY\') < :end)
+                (ot.dueDate IS NOT NULL AND ot.dueDate < :end) OR
+                (ot.dueDate IS NULL AND ot.dueDaysFromEntry IS NOT NULL AND DATE_ADD(o.entryDate, ot.dueDaysFromEntry, \'DAY\') < :end)
             )')
-            ->setParameter('start', $start)
             ->setParameter('end', $end)
             ->orderBy('ot.dueDate', 'ASC')
             ->getQuery()


### PR DESCRIPTION
## Summary
- add `SendDueEmailsCommand` to deliver due onboarding emails
- extend `EmailService` with generic send helper
- provide repository query to find tasks whose emails are due
- expose final assigned email on `OnboardingTask`

## Testing
- `composer install -n --no-scripts`
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68835149cdf88331b7e4b58214b9106e