### PR TITLE
Add required manager/buddy fields

### DIFF
--- a/migrations/Version20250802000000.php
+++ b/migrations/Version20250802000000.php
@@ -16,10 +16,10 @@ final class Version20250802000000 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        $this->addSql("UPDATE onboarding SET manager = '' WHERE manager IS NULL");
-        $this->addSql("UPDATE onboarding SET manager_email = '' WHERE manager_email IS NULL");
-        $this->addSql("UPDATE onboarding SET buddy = '' WHERE buddy IS NULL");
-        $this->addSql("UPDATE onboarding SET buddy_email = '' WHERE buddy_email IS NULL");
+        $this->addSql("UPDATE onboarding SET manager = 'Not Assigned' WHERE manager IS NULL");
+        $this->addSql("UPDATE onboarding SET manager_email = 'Not Assigned' WHERE manager_email IS NULL");
+        $this->addSql("UPDATE onboarding SET buddy = 'Not Assigned' WHERE buddy IS NULL");
+        $this->addSql("UPDATE onboarding SET buddy_email = 'Not Assigned' WHERE buddy_email IS NULL");
 
         $this->addSql('ALTER TABLE onboarding CHANGE manager manager VARCHAR(255) NOT NULL');
         $this->addSql('ALTER TABLE onboarding CHANGE manager_email manager_email VARCHAR(255) NOT NULL');

--- a/migrations/Version20250802000000.php
+++ b/migrations/Version20250802000000.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250802000000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Make manager and buddy related fields mandatory';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql("UPDATE onboarding SET manager = '' WHERE manager IS NULL");
+        $this->addSql("UPDATE onboarding SET manager_email = '' WHERE manager_email IS NULL");
+        $this->addSql("UPDATE onboarding SET buddy = '' WHERE buddy IS NULL");
+        $this->addSql("UPDATE onboarding SET buddy_email = '' WHERE buddy_email IS NULL");
+
+        $this->addSql('ALTER TABLE onboarding CHANGE manager manager VARCHAR(255) NOT NULL');
+        $this->addSql('ALTER TABLE onboarding CHANGE manager_email manager_email VARCHAR(255) NOT NULL');
+        $this->addSql('ALTER TABLE onboarding CHANGE buddy buddy VARCHAR(255) NOT NULL');
+        $this->addSql('ALTER TABLE onboarding CHANGE buddy_email buddy_email VARCHAR(255) NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE onboarding CHANGE manager manager VARCHAR(255) DEFAULT NULL');
+        $this->addSql('ALTER TABLE onboarding CHANGE manager_email manager_email VARCHAR(255) DEFAULT NULL');
+        $this->addSql('ALTER TABLE onboarding CHANGE buddy buddy VARCHAR(255) DEFAULT NULL');
+        $this->addSql('ALTER TABLE onboarding CHANGE buddy_email buddy_email VARCHAR(255) DEFAULT NULL');
+    }
+}

--- a/src/Entity/Onboarding.php
+++ b/src/Entity/Onboarding.php
@@ -37,7 +37,7 @@ class Onboarding
     private ?string $managerEmail = null;
 
     #[ORM\Column(length: 255)]
-    private ?string $buddy = null;
+    private string $buddy = '';
 
     #[ORM\Column(length: 255)]
     private ?string $buddyEmail = null;

--- a/src/Entity/Onboarding.php
+++ b/src/Entity/Onboarding.php
@@ -31,7 +31,7 @@ class Onboarding
     private ?string $team = null;
 
     #[ORM\Column(length: 255)]
-    private ?string $manager = null;
+    private string $manager;
 
     #[ORM\Column(length: 255)]
     private ?string $managerEmail = null;

--- a/src/Entity/Onboarding.php
+++ b/src/Entity/Onboarding.php
@@ -40,7 +40,7 @@ class Onboarding
     private string $buddy = '';
 
     #[ORM\Column(length: 255)]
-    private ?string $buddyEmail = null;
+    private string $buddyEmail = '';
 
     #[ORM\ManyToOne(targetEntity: OnboardingType::class, inversedBy: 'onboardings')]
     #[ORM\JoinColumn(nullable: false)]

--- a/src/Entity/Onboarding.php
+++ b/src/Entity/Onboarding.php
@@ -30,16 +30,16 @@ class Onboarding
     #[ORM\Column(length: 255, nullable: true)]
     private ?string $team = null;
 
-    #[ORM\Column(length: 255, nullable: true)]
+    #[ORM\Column(length: 255)]
     private ?string $manager = null;
 
-    #[ORM\Column(length: 255, nullable: true)]
+    #[ORM\Column(length: 255)]
     private ?string $managerEmail = null;
 
-    #[ORM\Column(length: 255, nullable: true)]
+    #[ORM\Column(length: 255)]
     private ?string $buddy = null;
 
-    #[ORM\Column(length: 255, nullable: true)]
+    #[ORM\Column(length: 255)]
     private ?string $buddyEmail = null;
 
     #[ORM\ManyToOne(targetEntity: OnboardingType::class, inversedBy: 'onboardings')]
@@ -147,7 +147,7 @@ class Onboarding
         return $this->manager;
     }
 
-    public function setManager(?string $manager): static
+    public function setManager(string $manager): static
     {
         $this->manager = $manager;
 
@@ -159,7 +159,7 @@ class Onboarding
         return $this->buddy;
     }
 
-    public function setBuddy(?string $buddy): static
+    public function setBuddy(string $buddy): static
     {
         $this->buddy = $buddy;
 
@@ -171,7 +171,7 @@ class Onboarding
         return $this->managerEmail;
     }
 
-    public function setManagerEmail(?string $managerEmail): static
+    public function setManagerEmail(string $managerEmail): static
     {
         $this->managerEmail = $managerEmail;
 
@@ -183,7 +183,7 @@ class Onboarding
         return $this->buddyEmail;
     }
 
-    public function setBuddyEmail(?string $buddyEmail): static
+    public function setBuddyEmail(string $buddyEmail): static
     {
         $this->buddyEmail = $buddyEmail;
 

--- a/templates/dashboard/onboarding_form.html.twig
+++ b/templates/dashboard/onboarding_form.html.twig
@@ -74,14 +74,14 @@
                     <div class="row">
                         <div class="col-md-6">
                             <div class="mb-3">
-                                <label for="manager" class="form-label">Führungskraft</label>
-                                <input type="text" class="form-control" id="manager" name="manager" placeholder="Name des direkten Vorgesetzten">
+                                <label for="manager" class="form-label">Führungskraft *</label>
+                                <input type="text" class="form-control" id="manager" name="manager" placeholder="Name des direkten Vorgesetzten" required>
                             </div>
                         </div>
                         <div class="col-md-6">
                             <div class="mb-3">
-                                <label for="managerEmail" class="form-label">E-Mail Führungskraft</label>
-                                <input type="email" class="form-control" id="managerEmail" name="managerEmail" placeholder="fk@arz.de">
+                                <label for="managerEmail" class="form-label">E-Mail Führungskraft *</label>
+                                <input type="email" class="form-control" id="managerEmail" name="managerEmail" placeholder="fk@arz.de" required>
                             </div>
                         </div>
                     </div>
@@ -89,14 +89,14 @@
                     <div class="row">
                         <div class="col-md-6">
                             <div class="mb-3">
-                                <label for="buddy" class="form-label">Buddy</label>
-                                <input type="text" class="form-control" id="buddy" name="buddy" placeholder="Name des Onboarding-Buddys">
+                                <label for="buddy" class="form-label">Buddy *</label>
+                                <input type="text" class="form-control" id="buddy" name="buddy" placeholder="Name des Onboarding-Buddys" required>
                             </div>
                         </div>
                         <div class="col-md-6">
                             <div class="mb-3">
-                                <label for="buddyEmail" class="form-label">Buddy E-Mail</label>
-                                <input type="email" class="form-control" id="buddyEmail" name="buddyEmail" placeholder="buddy@arz.de">
+                                <label for="buddyEmail" class="form-label">Buddy E-Mail *</label>
+                                <input type="email" class="form-control" id="buddyEmail" name="buddyEmail" placeholder="buddy@arz.de" required>
                             </div>
                         </div>
                     </div>
@@ -121,7 +121,7 @@
             </div>
             <div class="card-body">
                 <h6>Pflichtfelder</h6>
-                <p class="small">Die Felder <strong>Vorname</strong>, <strong>Nachname</strong> und <strong>Eintrittsdatum</strong> sind erforderlich.</p>
+                <p class="small">Die Felder <strong>Vorname</strong>, <strong>Nachname</strong>, <strong>Eintrittsdatum</strong>, <strong>Führungskraft</strong>, <strong>E-Mail Führungskraft</strong>, <strong>Buddy</strong> und <strong>Buddy E-Mail</strong> sind erforderlich.</p>
                 
                 <h6>Onboarding-Typ</h6>
                 <p class="small">Wählen Sie einen Onboarding-Typ um automatisch die entsprechenden Aufgaben zu erstellen.</p>


### PR DESCRIPTION
## Summary
- make manager and buddy data columns mandatory
- enforce mandatory fields in onboarding form
- describe mandatory fields in new hint text
- add migration to update existing database schema

## Testing
- `vendor/bin/phpunit --configuration phpunit.dist.xml`

------
https://chatgpt.com/codex/tasks/task_e_6883535fdbb48331bbceef66c1fc895e