### PR TITLE
Add role management routes

### DIFF
--- a/src/Controller/Admin/SettingsController.php
+++ b/src/Controller/Admin/SettingsController.php
@@ -162,6 +162,46 @@ class SettingsController extends AbstractController
         return $this->render('admin/role_form.html.twig');
     }
 
+    #[Route('/role/{id}', name: 'app_admin_role_show')]
+    public function showRole(Role $role): Response
+    {
+        return $this->render('admin/role_show.html.twig', [
+            'role' => $role,
+        ]);
+    }
+
+    #[Route('/role/{id}/edit', name: 'app_admin_role_edit')]
+    public function editRole(Request $request, Role $role, EntityManagerInterface $entityManager): Response
+    {
+        if ($request->isMethod('POST')) {
+            $role->setName($request->request->get('name'));
+            $role->setEmail($request->request->get('email'));
+            $role->setDescription($request->request->get('description'));
+            $role->setUpdatedAt(new \DateTimeImmutable());
+
+            $entityManager->flush();
+
+            $this->addFlash('success', 'Rolle wurde erfolgreich aktualisiert!');
+
+            return $this->redirectToRoute('app_admin_roles');
+        }
+
+        return $this->render('admin/role_form.html.twig', [
+            'role' => $role,
+        ]);
+    }
+
+    #[Route('/role/{id}/delete', name: 'app_admin_role_delete')]
+    public function deleteRole(Role $role, EntityManagerInterface $entityManager): Response
+    {
+        $entityManager->remove($role);
+        $entityManager->flush();
+
+        $this->addFlash('success', 'Rolle wurde erfolgreich gel\u00f6scht!');
+
+        return $this->redirectToRoute('app_admin_roles');
+    }
+
     #[Route('/onboarding-type/new', name: 'app_admin_onboarding_type_new')]
     public function newOnboardingType(Request $request, EntityManagerInterface $entityManager): Response
     {

--- a/templates/admin/role_form.html.twig
+++ b/templates/admin/role_form.html.twig
@@ -1,12 +1,15 @@
 {% extends 'base.html.twig' %}
 
-{% block title %}Neue Rolle - Administration - {{ parent() }}{% endblock %}
+{% set edit = role is defined %}
+{% block title %}{{ edit ? 'Rolle bearbeiten' : 'Neue Rolle' }} - Administration - {{ parent() }}{% endblock %}
 
 {% block body %}
 <div class="d-flex justify-content-between align-items-center mb-4">
     <div>
-        <h1><i class="bi bi-person-badge me-2"></i>Neue Rolle</h1>
-        <p class="text-muted mb-0">Erstellen Sie eine neue Rolle für Aufgaben-Zuweisungen</p>
+        <h1><i class="bi bi-person-badge me-2"></i>{{ edit ? 'Rolle bearbeiten' : 'Neue Rolle' }}</h1>
+        <p class="text-muted mb-0">
+            {{ edit ? 'Bearbeiten Sie eine vorhandene Rolle' : 'Erstellen Sie eine neue Rolle f\u00fcr Aufgaben-Zuweisungen' }}
+        </p>
     </div>
     <a href="{{ path('app_admin_roles') }}" class="btn btn-outline-secondary">
         <i class="bi bi-arrow-left me-1"></i>Zurück zur Übersicht
@@ -24,7 +27,7 @@
                 
                 <div class="mb-3">
                     <label for="name" class="form-label">Rollenname</label>
-                    <input type="text" class="form-control" id="name" name="name" placeholder="Geben Sie den Namen der Rolle ein..." required>
+                    <input type="text" class="form-control" id="name" name="name" value="{{ role.name ?? '' }}" placeholder="Geben Sie den Namen der Rolle ein..." required>
                     <div class="form-text">
                         Der Name der Rolle, z.B. "HR Manager", "IT Administrator" oder "Teamleiter"
                     </div>
@@ -32,7 +35,7 @@
 
                 <div class="mb-3">
                     <label for="email" class="form-label">E-Mail-Adresse</label>
-                    <input type="email" class="form-control" id="email" name="email" placeholder="name@firma.de" required>
+                    <input type="email" class="form-control" id="email" name="email" value="{{ role.email ?? '' }}" placeholder="name@firma.de" required>
                     <div class="form-text">
                         Die E-Mail-Adresse an die Aufgaben-Benachrichtigungen gesendet werden
                     </div>
@@ -40,7 +43,7 @@
 
                 <div class="mb-3">
                     <label for="description" class="form-label">Beschreibung</label>
-                    <textarea class="form-control" id="description" name="description" rows="3" placeholder="Beschreiben Sie die Verantwortlichkeiten dieser Rolle..."></textarea>
+                    <textarea class="form-control" id="description" name="description" rows="3" placeholder="Beschreiben Sie die Verantwortlichkeiten dieser Rolle...">{{ role.description ?? '' }}</textarea>
                     <div class="form-text">
                         Eine Beschreibung der Rolle und ihrer Aufgaben (optional)
                     </div>
@@ -48,7 +51,7 @@
 
                 <div class="d-flex justify-content-between">
                     <button type="submit" class="btn btn-primary">
-                        <i class="bi bi-check-circle me-1"></i>Rolle erstellen
+                        <i class="bi bi-check-circle me-1"></i>{{ edit ? 'Rolle speichern' : 'Rolle erstellen' }}
                     </button>
                     <a href="{{ path('app_admin_roles') }}" class="btn btn-outline-secondary">
                         <i class="bi bi-x-circle me-1"></i>Abbrechen

--- a/templates/admin/role_show.html.twig
+++ b/templates/admin/role_show.html.twig
@@ -1,0 +1,65 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}Rolle {{ role.name }} - Administration - {{ parent() }}{% endblock %}
+
+{% block body %}
+<div class="d-flex justify-content-between align-items-center mb-4">
+    <div>
+        <h1><i class="bi bi-person-badge me-2"></i>{{ role.name }}</h1>
+        <p class="text-muted mb-0">Details der Rolle</p>
+    </div>
+    <a href="{{ path('app_admin_roles') }}" class="btn btn-outline-secondary">
+        <i class="bi bi-arrow-left me-1"></i>Zurück zur Übersicht
+    </a>
+</div>
+
+<div class="card">
+    <div class="card-body">
+        <dl class="row mb-4">
+            <dt class="col-sm-3">ID</dt>
+            <dd class="col-sm-9">{{ role.id }}</dd>
+            <dt class="col-sm-3">E-Mail</dt>
+            <dd class="col-sm-9"><a href="mailto:{{ role.email }}">{{ role.email }}</a></dd>
+            <dt class="col-sm-3">Beschreibung</dt>
+            <dd class="col-sm-9">{{ role.description ?? '-' }}</dd>
+            <dt class="col-sm-3">Erstellt</dt>
+            <dd class="col-sm-9">{{ role.createdAt|date('d.m.Y H:i') }}</dd>
+        </dl>
+
+        <h5>Zugeordnete Aufgaben</h5>
+        {% if role.tasks|length > 0 %}
+            <div class="table-responsive">
+                <table class="table table-sm">
+                    <thead>
+                        <tr>
+                            <th>Titel</th>
+                            <th>Block</th>
+                            <th>Reihenfolge</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                    {% for task in role.tasks|sort((a, b) => a.sortOrder <=> b.sortOrder) %}
+                        <tr>
+                            <td>{{ task.title }}</td>
+                            <td>{{ task.taskBlock.name ?? '-' }}</td>
+                            <td>{{ task.sortOrder }}</td>
+                        </tr>
+                    {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        {% else %}
+            <p class="text-muted">Dieser Rolle sind keine Aufgaben zugeordnet.</p>
+        {% endif %}
+
+        <div class="d-flex justify-content-end">
+            <a href="{{ path('app_admin_role_edit', {'id': role.id}) }}" class="btn btn-warning me-2">
+                <i class="bi bi-pencil"></i> Bearbeiten
+            </a>
+            <a href="{{ path('app_admin_role_delete', {'id': role.id}) }}" class="btn btn-danger" onclick="return confirm('Wirklich löschen?');">
+                <i class="bi bi-trash"></i> Löschen
+            </a>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/templates/admin/roles.html.twig
+++ b/templates/admin/roles.html.twig
@@ -56,13 +56,13 @@
                                 </td>
                                 <td>
                                     <div class="btn-group btn-group-sm">
-                                        <a href="#" class="btn btn-outline-primary">
+                                        <a href="{{ path('app_admin_role_show', {'id': role.id}) }}" class="btn btn-outline-primary" title="Anzeigen">
                                             <i class="bi bi-eye"></i>
                                         </a>
-                                        <a href="#" class="btn btn-outline-warning">
+                                        <a href="{{ path('app_admin_role_edit', {'id': role.id}) }}" class="btn btn-outline-warning" title="Bearbeiten">
                                             <i class="bi bi-pencil"></i>
                                         </a>
-                                        <a href="#" class="btn btn-outline-danger">
+                                        <a href="{{ path('app_admin_role_delete', {'id': role.id}) }}" class="btn btn-outline-danger" onclick="return confirm('Wirklich löschen?');" title="Löschen">
                                             <i class="bi bi-trash"></i>
                                         </a>
                                     </div>


### PR DESCRIPTION
## Summary
- enable show/edit/delete for roles in settings controller
- adjust role form for edit mode
- add role details page and update actions in list

## Testing
- `composer install --no-interaction` *(fails: CONNECT tunnel failed)*
- `./vendor/bin/phpunit -c phpunit.dist.xml --stop-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_688362cd075083318cd9009164498cfd