### PR TITLE
Fix edit detection in onboarding task form

### DIFF
--- a/templates/dashboard/onboarding_task_form.html.twig
+++ b/templates/dashboard/onboarding_task_form.html.twig
@@ -1,6 +1,6 @@
 {% extends 'base.html.twig' %}
 
-{% set edit = task is defined %}
+{% set edit = task is defined and task is not null %}
 
 {% block title %}{% if edit %}Aufgabe bearbeiten{% else %}Neue Aufgabe{% endif %} - {{ onboarding.fullName }}{% endblock %}
 


### PR DESCRIPTION
## Summary
- update Twig template to detect null task in task form

## Testing
- `composer install --no-interaction` *(fails: importmap:install)*
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68836353a0348331ac671215d8ff41fc