### PR TITLE
Implement email template variables

### DIFF
--- a/src/Command/SendDueEmailsCommand.php
+++ b/src/Command/SendDueEmailsCommand.php
@@ -36,10 +36,13 @@ class SendDueEmailsCommand extends Command
             }
 
             try {
+                $content = $task->getEmailTemplate() ?? '';
+                $content = $this->emailService->renderTemplate($content, $task);
+
                 $this->emailService->sendEmail(
                     $recipient,
                     'Aufgabe fällig: ' . $task->getTitle(),
-                    $task->getEmailTemplate() ?? ''
+                    $content
                 );
                 $task->setEmailSentAt(new \DateTimeImmutable());
             } catch (\Throwable $e) {

--- a/src/Service/EmailService.php
+++ b/src/Service/EmailService.php
@@ -3,6 +3,7 @@
 namespace App\Service;
 
 use App\Entity\EmailSettings;
+use App\Entity\OnboardingTask;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Mailer\Transport;
 use Symfony\Component\Mime\Email;
@@ -29,6 +30,26 @@ class EmailService
     public function sendEmail(string $recipient, string $subject, string $html): void
     {
         $this->sendEmailInternal($recipient, $subject, $html, true);
+    }
+
+    /**
+     * Renders an email template with onboarding specific placeholders.
+     */
+    public function renderTemplate(string $template, OnboardingTask $task): string
+    {
+        $onboarding = $task->getOnboarding();
+
+        $placeholders = [
+            '{{firstName}}'    => $onboarding?->getFirstName() ?? '',
+            '{{lastName}}'     => $onboarding?->getLastName() ?? '',
+            '{{entryDate}}'    => $onboarding?->getEntryDate()?->format('Y-m-d') ?? '',
+            '{{onboardingId}}' => $onboarding?->getId() ?? '',
+            '{{taskId}}'       => $task->getId() ?? '',
+            '{{manager}}'      => $onboarding?->getManager() ?? '',
+            '{{buddy}}'        => $onboarding?->getBuddy() ?? '',
+        ];
+
+        return strtr($template, $placeholders);
     }
 
     private function sendEmailInternal(string $recipient, string $subject, string $content, bool $isHtml): void

--- a/tests/EmailServiceTest.php
+++ b/tests/EmailServiceTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Tests;
+
+use App\Entity\Onboarding;
+use App\Entity\OnboardingTask;
+use App\Service\EmailService;
+use App\Service\PasswordEncryptionService;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
+
+class EmailServiceTest extends TestCase
+{
+    public function testRenderTemplateReplacesVariables(): void
+    {
+        $parameterBag = new ParameterBag(['kernel.secret' => 'test-secret-key']);
+        $service = new EmailService(
+            $this->createMock(EntityManagerInterface::class),
+            new PasswordEncryptionService($parameterBag)
+        );
+
+        $onboarding = new Onboarding();
+        $onboarding->setFirstName('Max');
+        $onboarding->setLastName('Mustermann');
+        $onboarding->setEntryDate(new \DateTimeImmutable('2024-01-01'));
+        $onboarding->setManager('Chef');
+        $onboarding->setBuddy('Buddy');
+
+        // set ID via reflection
+        $r = new \ReflectionProperty(Onboarding::class, 'id');
+        $r->setAccessible(true);
+        $r->setValue($onboarding, 7);
+
+        $task = new OnboardingTask();
+        $task->setOnboarding($onboarding);
+        $r2 = new \ReflectionProperty(OnboardingTask::class, 'id');
+        $r2->setAccessible(true);
+        $r2->setValue($task, 42);
+
+        $template = 'Hallo {{firstName}} {{lastName}}, {{entryDate}}, {{onboardingId}}, {{taskId}}, {{manager}}, {{buddy}}';
+        $result = $service->renderTemplate($template, $task);
+
+        $this->assertSame(
+            'Hallo Max Mustermann, 2024-01-01, 7, 42, Chef, Buddy',
+            $result
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- support placeholders in email templates
- insert variable replacement in the due email command
- add tests for template rendering

## Testing
- `./vendor/bin/phpunit`
- `php bin/console lint:twig templates/`
- `php bin/console lint:yaml config/`

------
https://chatgpt.com/codex/tasks/task_e_68836dc982908331bfebba7ef1b6be20