### PR TITLE
Add public task completion links

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -30,6 +30,7 @@ security:
     access_control:
         - { path: ^/login, roles: PUBLIC_ACCESS }
         - { path: ^/logout, roles: PUBLIC_ACCESS }
+        - { path: ^/complete-task, roles: PUBLIC_ACCESS }
         - { path: ^/, roles: ROLE_USER }
 
 when@test:

--- a/migrations/Version20250803000000.php
+++ b/migrations/Version20250803000000.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250803000000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Adds completion token to onboarding_task';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql("ALTER TABLE onboarding_task ADD completion_token VARCHAR(64) NOT NULL");
+        $this->addSql("UPDATE onboarding_task SET completion_token = SUBSTRING(MD5(RAND()),1,32)");
+        $this->addSql("ALTER TABLE onboarding_task ADD UNIQUE INDEX UNIQ_FCE27CE3CDE9BDAB (completion_token)");
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE onboarding_task DROP INDEX UNIQ_FCE27CE3CDE9BDAB');
+        $this->addSql('ALTER TABLE onboarding_task DROP completion_token');
+    }
+}

--- a/src/Controller/PublicTaskController.php
+++ b/src/Controller/PublicTaskController.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Controller;
+
+use App\Entity\OnboardingTask;
+use App\Repository\OnboardingTaskRepository;
+use App\Service\TaskStatusService;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+
+class PublicTaskController extends AbstractController
+{
+    public function __construct(private readonly TaskStatusService $taskStatus)
+    {
+    }
+
+    #[Route('/complete-task/{token}', name: 'app_public_task_complete')]
+    public function complete(string $token, OnboardingTaskRepository $repository): Response
+    {
+        $task = $repository->findOneByCompletionToken($token);
+        if (!$task) {
+            return new Response('Ungültiger Link.', Response::HTTP_NOT_FOUND);
+        }
+
+        if (OnboardingTask::STATUS_COMPLETED !== $task->getStatus()) {
+            $this->taskStatus->markAsCompleted($task);
+        }
+
+        return $this->render('public/task_complete.html.twig');
+    }
+}

--- a/src/Entity/OnboardingTask.php
+++ b/src/Entity/OnboardingTask.php
@@ -49,6 +49,9 @@ class OnboardingTask
     #[ORM\Column(type: 'text', nullable: true)]
     private ?string $emailTemplate = null;
 
+    #[ORM\Column(length: 64, unique: true)]
+    private string $completionToken;
+
     // Beziehungen
     #[ORM\ManyToOne(targetEntity: Onboarding::class, inversedBy: 'onboardingTasks')]
     #[ORM\JoinColumn(nullable: false)]
@@ -99,6 +102,7 @@ class OnboardingTask
         $this->updatedAt = new \DateTimeImmutable();
         $this->dependencies = new ArrayCollection();
         $this->dependentTasks = new ArrayCollection();
+        $this->completionToken = bin2hex(random_bytes(16));
     }
 
     // Getter und Setter
@@ -371,6 +375,18 @@ class OnboardingTask
     public function setEmailSentAt(?\DateTimeImmutable $emailSentAt): static
     {
         $this->emailSentAt = $emailSentAt;
+
+        return $this;
+    }
+
+    public function getCompletionToken(): string
+    {
+        return $this->completionToken;
+    }
+
+    public function regenerateCompletionToken(): static
+    {
+        $this->completionToken = bin2hex(random_bytes(16));
 
         return $this;
     }

--- a/src/Repository/OnboardingTaskRepository.php
+++ b/src/Repository/OnboardingTaskRepository.php
@@ -87,4 +87,13 @@ class OnboardingTaskRepository extends ServiceEntityRepository
             ->getQuery()
             ->getResult();
     }
+
+    public function findOneByCompletionToken(string $token): ?OnboardingTask
+    {
+        return $this->createQueryBuilder('ot')
+            ->where('ot.completionToken = :token')
+            ->setParameter('token', $token)
+            ->getQuery()
+            ->getOneOrNullResult();
+    }
 }

--- a/src/Service/EmailService.php
+++ b/src/Service/EmailService.php
@@ -56,6 +56,11 @@ class EmailService
                 ['id' => $onboarding->getId()],
                 UrlGeneratorInterface::ABSOLUTE_URL
             ) : '',
+            '{{taskCompleteLink}}' => $this->urlGenerator->generate(
+                'app_public_task_complete',
+                ['token' => $task->getCompletionToken()],
+                UrlGeneratorInterface::ABSOLUTE_URL
+            ),
         ];
 
         return strtr($template, $placeholders);

--- a/templates/public/task_complete.html.twig
+++ b/templates/public/task_complete.html.twig
@@ -1,0 +1,10 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}Aufgabe erledigt - {{ parent() }}{% endblock %}
+
+{% block body %}
+<div class="text-center py-5">
+    <i class="bi bi-check-circle display-1 text-success"></i>
+    <h3 class="mt-3">Aufgabe wurde erfolgreich als erledigt markiert.</h3>
+</div>
+{% endblock %}

--- a/tests/EmailServiceTest.php
+++ b/tests/EmailServiceTest.php
@@ -15,9 +15,13 @@ class EmailServiceTest extends TestCase
     public function testRenderTemplateReplacesVariables(): void
     {
         $parameterBag = new ParameterBag(['kernel.secret' => 'test-secret-key']);
+        $urlGenerator = $this->createMock(\Symfony\Component\Routing\Generator\UrlGeneratorInterface::class);
+        $urlGenerator->method('generate')->willReturn('http://example.com');
+
         $service = new EmailService(
             $this->createMock(EntityManagerInterface::class),
-            new PasswordEncryptionService($parameterBag)
+            new PasswordEncryptionService($parameterBag),
+            $urlGenerator
         );
 
         $onboarding = new Onboarding();


### PR DESCRIPTION
## Summary
- add completionToken property for OnboardingTask
- create PublicTaskController with new route
- display completion success page
- update EmailService to expose taskCompleteLink variable
- allow /complete-task route without login
- add migration for completion token
- update EmailService test for UrlGenerator

## Testing
- `composer install --no-interaction --no-scripts`
- `vendor/bin/phpunit --testdox`
- `php bin/console lint:twig templates`
- `php bin/console lint:yaml config`


------
https://chatgpt.com/codex/tasks/task_e_6883809780488331bc63d835bb84a607