### PR TITLE
Add command tests

### DIFF
--- a/tests/Command/ProcessTasksCommandTest.php
+++ b/tests/Command/ProcessTasksCommandTest.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace App\Command;
+
+// Override exec within this namespace for testing
+function exec(string $command, ?array &$output = null, ?int &$exitCode = null): void
+{
+    \App\Tests\Command\ProcessTasksCommandTest::recordExec($command, $output, $exitCode);
+}
+
+namespace App\Tests\Command;
+
+use App\Command\ProcessTasksCommand;
+use App\Entity\OnboardingTask;
+use App\Repository\OnboardingTaskRepository;
+use App\Service\EmailService;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class ProcessTasksCommandTest extends TestCase
+{
+    private static array $execCommands = [];
+    private static int $nextExitCode = 0;
+
+    public static function recordExec(string $command, ?array &$output = null, ?int &$exitCode = null): void
+    {
+        self::$execCommands[] = $command;
+        $output = ['ok'];
+        $exitCode = self::$nextExitCode;
+    }
+
+    private EntityManagerInterface $em;
+    private EmailService $emailService;
+    private OnboardingTaskRepository $repo;
+    private CommandTester $tester;
+    private ProcessTasksCommand $command;
+
+    protected function setUp(): void
+    {
+        self::$execCommands = [];
+        self::$nextExitCode = 0;
+
+        $this->em = $this->createMock(EntityManagerInterface::class);
+        $this->emailService = $this->createMock(EmailService::class);
+        $this->repo = $this->createMock(OnboardingTaskRepository::class);
+
+        $this->em->method('getRepository')->with(OnboardingTask::class)->willReturn($this->repo);
+
+        $this->command = new ProcessTasksCommand($this->em, $this->emailService);
+        $this->tester = new CommandTester($this->command);
+    }
+
+    public function testExecuteProcessesEmailAndApiTasks(): void
+    {
+        $taskEmail = (new OnboardingTask())
+            ->setActionType(OnboardingTask::ACTION_EMAIL)
+            ->setAssignedEmail('a@example.com')
+            ->setEmailTemplate('tpl');
+
+        $taskApi = (new OnboardingTask())
+            ->setActionType(OnboardingTask::ACTION_API)
+            ->setApiUrl('curl http://example.com');
+
+        $this->repo->method('findTasksDueForDate')->willReturn([$taskEmail, $taskApi]);
+
+        $this->emailService->expects($this->once())
+            ->method('renderTemplate')
+            ->willReturn('content');
+        $this->emailService->expects($this->once())
+            ->method('sendEmail');
+        $this->emailService->expects($this->once())
+            ->method('renderUrlEncodedTemplate')
+            ->with('curl http://example.com', $taskApi)
+            ->willReturn('curl http://example.com');
+
+        $this->em->expects($this->once())->method('flush');
+
+        $exit = $this->tester->execute([]);
+
+        $this->assertSame(Command::SUCCESS, $exit);
+        $this->assertStringContainsString('2 Tasks verarbeitet.', $this->tester->getDisplay());
+        $this->assertCount(1, self::$execCommands);
+        $this->assertSame('curl http://example.com', self::$execCommands[0]);
+    }
+
+    public function testCommandMetadata(): void
+    {
+        $this->assertSame('app:process-tasks', $this->command->getName());
+        $this->assertNotEmpty($this->command->getDescription());
+    }
+}

--- a/tests/Command/SendDueEmailsCommandTest.php
+++ b/tests/Command/SendDueEmailsCommandTest.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace App\Tests\Command;
+
+use App\Command\SendDueEmailsCommand;
+use App\Entity\OnboardingTask;
+use App\Repository\OnboardingTaskRepository;
+use App\Service\EmailService;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class SendDueEmailsCommandTest extends TestCase
+{
+    private EntityManagerInterface $entityManager;
+    private EmailService $emailService;
+    private OnboardingTaskRepository $repository;
+    private CommandTester $tester;
+    private SendDueEmailsCommand $command;
+
+    protected function setUp(): void
+    {
+        $this->entityManager = $this->createMock(EntityManagerInterface::class);
+        $this->emailService = $this->createMock(EmailService::class);
+        $this->repository = $this->createMock(OnboardingTaskRepository::class);
+
+        $this->entityManager
+            ->method('getRepository')
+            ->with(OnboardingTask::class)
+            ->willReturn($this->repository);
+
+        $this->command = new SendDueEmailsCommand($this->entityManager, $this->emailService);
+        $this->tester = new CommandTester($this->command);
+    }
+
+    public function testExecuteSendsEmailsForDueTasks(): void
+    {
+        $task1 = (new OnboardingTask())
+            ->setActionType(OnboardingTask::ACTION_EMAIL)
+            ->setAssignedEmail('a@example.com')
+            ->setEmailTemplate('tpl');
+        $task2 = (new OnboardingTask())
+            ->setActionType(OnboardingTask::ACTION_EMAIL)
+            ->setAssignedEmail('b@example.com')
+            ->setEmailTemplate('tpl2');
+
+        $this->repository
+            ->method('findTasksDueForDate')
+            ->willReturn([$task1, $task2]);
+
+        $this->emailService
+            ->expects($this->exactly(2))
+            ->method('renderTemplate')
+            ->willReturn('content');
+        $this->emailService
+            ->expects($this->exactly(2))
+            ->method('sendEmail');
+
+        $this->entityManager->expects($this->once())->method('flush');
+
+        $exitCode = $this->tester->execute([]);
+
+        $this->assertSame(Command::SUCCESS, $exitCode);
+        $this->assertStringContainsString('2 E-Mails verarbeitet.', $this->tester->getDisplay());
+    }
+
+    public function testExecuteSkipsTasksWithoutRecipient(): void
+    {
+        $task = (new OnboardingTask())
+            ->setActionType(OnboardingTask::ACTION_EMAIL)
+            ->setEmailTemplate('tpl');
+
+        $this->repository
+            ->method('findTasksDueForDate')
+            ->willReturn([$task]);
+
+        $this->emailService->expects($this->never())->method('sendEmail');
+        $this->entityManager->expects($this->once())->method('flush');
+
+        $exitCode = $this->tester->execute([]);
+
+        $this->assertSame(Command::SUCCESS, $exitCode);
+        $this->assertStringContainsString('1 E-Mails verarbeitet.', $this->tester->getDisplay());
+    }
+
+    public function testCommandMetadata(): void
+    {
+        $this->assertSame('app:send-due-emails', $this->command->getName());
+        $this->assertNotEmpty($this->command->getDescription());
+    }
+}

--- a/tests/Command/TestEmailCommandTest.php
+++ b/tests/Command/TestEmailCommandTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Tests\Command;
+
+use App\Command\TestEmailCommand;
+use App\Service\EmailService;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class TestEmailCommandTest extends TestCase
+{
+    public function testExecute(): void
+    {
+        $service = $this->createMock(EmailService::class);
+        $service->expects($this->once())
+            ->method('sendTestMail')
+            ->with('test@example.com', 'Testnachricht', 'Dies ist eine Test-E-Mail.');
+
+        $command = new TestEmailCommand($service);
+        $tester = new CommandTester($command);
+
+        $exitCode = $tester->execute(['recipient' => 'test@example.com']);
+
+        $this->assertSame(Command::SUCCESS, $exitCode);
+        $this->assertStringContainsString('E-Mail wurde versendet', $tester->getDisplay());
+    }
+
+    public function testCommandMetadata(): void
+    {
+        $service = $this->createMock(EmailService::class);
+        $command = new TestEmailCommand($service);
+
+        $this->assertSame('app:test-email', $command->getName());
+        $this->assertNotEmpty($command->getDescription());
+    }
+}

--- a/tests/Command/UserCommandTest.php
+++ b/tests/Command/UserCommandTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace App\Tests\Command;
+
+use App\Command\UserCommand;
+use App\Entity\User;
+use App\Repository\UserRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+class UserCommandTest extends TestCase
+{
+    private EntityManagerInterface $em;
+    private UserPasswordHasherInterface $hasher;
+    private UserRepository $repo;
+    private CommandTester $tester;
+
+    protected function setUp(): void
+    {
+        $this->em = $this->createMock(EntityManagerInterface::class);
+        $this->hasher = $this->createMock(UserPasswordHasherInterface::class);
+        $this->repo = $this->createMock(UserRepository::class);
+
+        $this->em->method('getRepository')->with(User::class)->willReturn($this->repo);
+
+        $command = new UserCommand($this->em, $this->hasher);
+        $this->tester = new CommandTester($command);
+    }
+
+    public function testExecuteWithInvalidEmail(): void
+    {
+        $exit = $this->tester->execute(['email' => 'invalid', 'password' => '12345678']);
+        $this->assertSame(Command::FAILURE, $exit);
+        $this->assertStringContainsString('Ungültige E-Mail-Adresse', $this->tester->getDisplay());
+    }
+
+    public function testExecuteWithShortPassword(): void
+    {
+        $exit = $this->tester->execute(['email' => 'test@example.com', 'password' => 'short']);
+        $this->assertSame(Command::FAILURE, $exit);
+        $this->assertStringContainsString('Passwort muss mindestens 8 Zeichen lang sein', $this->tester->getDisplay());
+    }
+
+    public function testExecuteCreatesNewUser(): void
+    {
+        $this->repo->method('findOneBy')->willReturn(null);
+        $this->hasher->expects($this->once())->method('hashPassword');
+        $this->em->expects($this->once())->method('persist');
+        $this->em->expects($this->once())->method('flush');
+
+        $exit = $this->tester->execute(['email' => 'new@example.com', 'password' => 'securepass']);
+
+        $this->assertSame(Command::SUCCESS, $exit);
+        $this->assertStringContainsString('Benutzer wurde erstellt', $this->tester->getDisplay());
+    }
+
+    public function testExecuteUpdatesExistingUser(): void
+    {
+        $user = new User();
+        $this->repo->method('findOneBy')->willReturn($user);
+        $this->hasher->expects($this->once())->method('hashPassword')->with($user, 'newpass123');
+        $this->em->expects($this->once())->method('persist')->with($user);
+        $this->em->expects($this->once())->method('flush');
+
+        $exit = $this->tester->execute(['email' => 'exists@example.com', 'password' => 'newpass123']);
+
+        $this->assertSame(Command::SUCCESS, $exit);
+        $this->assertStringContainsString('Passwort wurde aktualisiert', $this->tester->getDisplay());
+    }
+}


### PR DESCRIPTION
## Summary
- add tests for SendDueEmailsCommand
- add tests for TestEmailCommand
- add tests for UserCommand
- add tests for ProcessTasksCommand

## Testing
- `COLUMNS=120 ./vendor/bin/phpunit --testdox`

------
https://chatgpt.com/codex/tasks/task_e_688617d68ba88331837c54a449e8a793