### PR TITLE
Add unit tests for controllers

### DIFF
--- a/tests/Controller/Admin/EmailSettingsControllerTest.php
+++ b/tests/Controller/Admin/EmailSettingsControllerTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Tests\Controller\Admin;
+
+use App\Controller\Admin\EmailSettingsController;
+use App\Entity\EmailSettings;
+use App\Service\PasswordEncryptionService;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\EntityRepository;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class EmailSettingsControllerTest extends TestCase
+{
+    public function testIndexRendersSettings(): void
+    {
+        $settings = new EmailSettings();
+
+        $repo = $this->createMock(EntityRepository::class);
+        $repo->method('findOneBy')->willReturn($settings);
+
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->method('getRepository')->willReturn($repo);
+
+        $em->expects($this->never())->method('persist');
+
+        $service = new PasswordEncryptionService(new ParameterBag(['kernel.secret' => 's']));
+
+        $controller = new class extends EmailSettingsController {
+            public array $args;
+            protected function render(string $view, array $parameters = [], ?Response $response = null): Response
+            {
+                $this->args = ['view' => $view, 'params' => $parameters];
+                return new Response();
+            }
+        };
+
+        $response = $controller->index(new Request(), $em, $service);
+
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertSame('admin/email_settings.html.twig', $controller->args['view']);
+        $this->assertSame(['settings' => $settings], $controller->args['params']);
+    }
+}

--- a/tests/Controller/Admin/OnboardingAdminControllerTest.php
+++ b/tests/Controller/Admin/OnboardingAdminControllerTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Tests\Controller\Admin;
+
+use App\Controller\Admin\OnboardingAdminController;
+use App\Entity\TaskBlock;
+use App\Service\AdminLookupService;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\EntityRepository;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Response;
+
+class OnboardingAdminControllerTest extends TestCase
+{
+    public function testTaskBlocksRendersView(): void
+    {
+        $repo = $this->createMock(EntityRepository::class);
+        $repo->method('findAll')->willReturn(['tb']);
+
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->method('getRepository')->willReturn($repo);
+
+        $lookup = $this->createMock(AdminLookupService::class);
+
+        $controller = new class($lookup) extends OnboardingAdminController {
+            public array $args;
+            protected function render(string $view, array $parameters = [], ?Response $response = null): Response
+            {
+                $this->args = ['view' => $view, 'params' => $parameters];
+                return new Response();
+            }
+        };
+
+        $response = $controller->taskBlocks($em);
+
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertSame('admin/task_blocks.html.twig', $controller->args['view']);
+        $this->assertSame(['taskBlocks' => ['tb']], $controller->args['params']);
+    }
+}

--- a/tests/Controller/Admin/SettingsControllerTest.php
+++ b/tests/Controller/Admin/SettingsControllerTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Tests\Controller\Admin;
+
+use App\Controller\Admin\SettingsController;
+use App\Entity\BaseType;
+use App\Entity\OnboardingType;
+use App\Entity\Role;
+use App\Entity\TaskBlock;
+use App\Entity\User;
+use App\Service\AdminLookupService;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\EntityRepository;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Response;
+
+class SettingsControllerTest extends TestCase
+{
+    public function testIndexRendersStats(): void
+    {
+        $repo = $this->createMock(EntityRepository::class);
+        $repo->method('count')->willReturn(1);
+
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->method('getRepository')->willReturn($repo);
+
+        $lookup = $this->createMock(AdminLookupService::class);
+
+        $controller = new class($lookup) extends SettingsController {
+            public array $args;
+            protected function render(string $view, array $parameters = [], ?Response $response = null): Response
+            {
+                $this->args = ['view' => $view, 'params' => $parameters];
+                return new Response();
+            }
+        };
+
+        $response = $controller->index($em);
+
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertSame('admin/index.html.twig', $controller->args['view']);
+        $this->assertSame(['stats' => [
+            'baseTypes' => 1,
+            'onboardingTypes' => 1,
+            'roles' => 1,
+            'taskBlocks' => 1,
+            'users' => 1,
+        ]], $controller->args['params']);
+    }
+}

--- a/tests/Controller/Admin/UserControllerTest.php
+++ b/tests/Controller/Admin/UserControllerTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Tests\Controller\Admin;
+
+use App\Controller\Admin\UserController;
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\EntityRepository;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+use Symfony\Component\HttpFoundation\Request;
+
+class UserControllerTest extends TestCase
+{
+    public function testListRendersUsers(): void
+    {
+        $repo = $this->createMock(EntityRepository::class);
+        $repo->method('findAll')->willReturn(['u']);
+
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->method('getRepository')->willReturn($repo);
+
+        $controller = new class extends UserController {
+            public array $args;
+            protected function render(string $view, array $parameters = [], ?Response $response = null): Response
+            {
+                $this->args = ['view' => $view, 'params' => $parameters];
+                return new Response();
+            }
+        };
+
+        $response = $controller->list($em);
+
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertSame('admin/users.html.twig', $controller->args['view']);
+        $this->assertSame(['users' => ['u']], $controller->args['params']);
+    }
+
+    public function testNewInvalidPassword(): void
+    {
+        $em = $this->createMock(EntityManagerInterface::class);
+        $hasher = $this->createMock(UserPasswordHasherInterface::class);
+
+        $controller = new class extends UserController {
+            public array $args;
+            public array $flashes = [];
+            protected function render(string $view, array $parameters = [], ?Response $response = null): Response
+            {
+                $this->args = ['view' => $view, 'params' => $parameters];
+                return new Response();
+            }
+            protected function addFlash(string $type, mixed $message): void
+            {
+                $this->flashes[$type][] = $message;
+            }
+        };
+
+        $request = new Request([], ['email' => 'a@b.c', 'password' => 'short']);
+        $controller->new($request, $em, $hasher);
+
+        $this->assertArrayHasKey('error', $controller->flashes);
+    }
+}

--- a/tests/Controller/OnboardingControllerTest.php
+++ b/tests/Controller/OnboardingControllerTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace App\Tests\Controller;
+
+use App\Controller\OnboardingController;
+use App\Entity\Onboarding;
+use App\Entity\OnboardingTask;
+use App\Entity\TaskBlock;
+use App\Service\OnboardingTaskFacade;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\EntityRepository;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Response;
+
+class OnboardingControllerTest extends TestCase
+{
+    public function testIndexRendersList(): void
+    {
+        $repo = $this->createMock(EntityRepository::class);
+        $repo->expects($this->once())
+            ->method('findBy')
+            ->willReturn(['ob']);
+
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->method('getRepository')->willReturn($repo);
+
+        $facade = $this->createMock(OnboardingTaskFacade::class);
+
+        $controller = new class($facade) extends OnboardingController {
+            public array $args;
+            protected function render(string $view, array $parameters = [], ?Response $response = null): Response
+            {
+                $this->args = ['view' => $view, 'params' => $parameters];
+                return new Response();
+            }
+        };
+
+        $response = $controller->index($em);
+
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertSame('dashboard/onboardings.html.twig', $controller->args['view']);
+        $this->assertSame(['onboardings' => ['ob']], $controller->args['params']);
+    }
+
+    public function testGroupTasksByBlock(): void
+    {
+        $onboarding = new Onboarding();
+
+        $block = new TaskBlock();
+        $block->setName('Block');
+
+        $task1 = new OnboardingTask();
+        $task1->setTaskBlock($block);
+        $task2 = new OnboardingTask();
+        $task2->setTaskBlock(null);
+
+        $onboarding->getOnboardingTasks()->add($task1);
+        $onboarding->getOnboardingTasks()->add($task2);
+
+        $facade = $this->createMock(OnboardingTaskFacade::class);
+        $controller = new OnboardingController($facade);
+
+        $ref = new \ReflectionClass($controller);
+        $method = $ref->getMethod('groupTasksByBlock');
+        $method->setAccessible(true);
+
+        $grouped = $method->invoke($controller, $onboarding);
+
+        $this->assertCount(2, $grouped);
+        $this->assertArrayHasKey('Block', $grouped);
+        $this->assertArrayHasKey('Sonderaufgaben', $grouped);
+    }
+}

--- a/tests/Controller/PublicTaskControllerTest.php
+++ b/tests/Controller/PublicTaskControllerTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Tests\Controller;
+
+use App\Controller\PublicTaskController;
+use App\Entity\OnboardingTask;
+use App\Repository\OnboardingTaskRepository;
+use App\Service\TaskStatusService;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Response;
+
+class PublicTaskControllerTest extends TestCase
+{
+    public function testCompleteMarksTask(): void
+    {
+        $task = new OnboardingTask();
+
+        $repo = $this->createMock(OnboardingTaskRepository::class);
+        $repo->method('findOneByCompletionToken')->willReturn($task);
+
+        $service = $this->createMock(TaskStatusService::class);
+        $service->expects($this->once())->method('markAsCompleted')->with($task);
+
+        $controller = new class($service) extends PublicTaskController {
+            public array $args;
+            protected function render(string $view, array $parameters = [], ?Response $response = null): Response
+            {
+                $this->args = ['view' => $view];
+                return new Response();
+            }
+        };
+
+        $response = $controller->complete('tok', $repo);
+
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertSame('public/task_complete.html.twig', $controller->args['view']);
+    }
+}

--- a/tests/Controller/SecurityControllerTest.php
+++ b/tests/Controller/SecurityControllerTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Tests\Controller;
+
+use App\Controller\SecurityController;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Http\Authentication\AuthenticationUtils;
+
+class SecurityControllerTest extends TestCase
+{
+    public function testLoginRendersTemplate(): void
+    {
+        $auth = $this->createMock(AuthenticationUtils::class);
+        $auth->method('getLastAuthenticationError')->willReturn(null);
+        $auth->method('getLastUsername')->willReturn('user');
+
+        $controller = new class extends SecurityController {
+            public array $args;
+            protected function render(string $view, array $parameters = [], ?Response $response = null): Response
+            {
+                $this->args = ['view' => $view, 'params' => $parameters];
+                return new Response();
+            }
+        };
+
+        $response = $controller->login($auth);
+
+        $this->assertSame('security/login.html.twig', $controller->args['view']);
+        $this->assertSame(['last_username' => 'user', 'error' => null], $controller->args['params']);
+        $this->assertInstanceOf(Response::class, $response);
+    }
+}

--- a/tests/Controller/TaskControllerTest.php
+++ b/tests/Controller/TaskControllerTest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace App\Tests\Controller;
+
+use App\Controller\TaskController;
+use App\Entity\Onboarding;
+use App\Entity\OnboardingTask;
+use App\Service\AdminLookupService;
+use App\Service\OnboardingTaskFacade;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class TaskControllerTest extends TestCase
+{
+    public function testToggleCompleteRedirectsToOverview(): void
+    {
+        $task = new OnboardingTask();
+        $task->setOnboarding(new Onboarding());
+
+        $facade = $this->createMock(OnboardingTaskFacade::class);
+        $facade->method('toggleStatus')->willReturn(['success', 'msg']);
+
+        $lookup = $this->createMock(AdminLookupService::class);
+
+        $controller = new class($facade, $lookup) extends TaskController {
+            public string $route = '';
+            protected function redirectToRoute(string $route, array $parameters = [], int $status = 302): \Symfony\Component\HttpFoundation\RedirectResponse
+            {
+                $this->route = $route;
+                return new \Symfony\Component\HttpFoundation\RedirectResponse('/dummy', $status);
+            }
+            protected function addFlash(string $type, mixed $message): void
+            {
+                // no-op in tests
+            }
+        };
+
+        $request = new Request([], [], [], [], [], ['HTTP_REFERER' => '/tasks']);
+        $response = $controller->toggleComplete($task, $request);
+
+        $this->assertSame('app_tasks_overview', $controller->route);
+        $this->assertSame(302, $response->getStatusCode());
+    }
+
+    public function testDeleteRemovesTask(): void
+    {
+        $task = new OnboardingTask();
+        $ob = new Onboarding();
+        $task->setOnboarding($ob);
+
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->expects($this->once())->method('remove')->with($task);
+        $em->expects($this->once())->method('flush');
+
+        $facade = $this->createMock(OnboardingTaskFacade::class);
+        $lookup = $this->createMock(AdminLookupService::class);
+
+        $controller = new class($facade, $lookup) extends TaskController {
+            public array $route;
+            protected function redirectToRoute(string $route, array $parameters = [], int $status = 302): \Symfony\Component\HttpFoundation\RedirectResponse
+            {
+                $this->route = [$route, $parameters];
+                return new \Symfony\Component\HttpFoundation\RedirectResponse('/dummy', $status);
+            }
+            protected function addFlash(string $type, mixed $message): void
+            {
+                // no-op
+            }
+        };
+
+        $response = $controller->delete($task, $em);
+
+        $this->assertSame('app_onboarding_detail', $controller->route[0]);
+        $this->assertEquals(['id' => $ob->getId()], $controller->route[1]);
+        $this->assertSame(302, $response->getStatusCode());
+    }
+}

--- a/tests/Controller/TaskFormControllerTest.php
+++ b/tests/Controller/TaskFormControllerTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Tests\Controller;
+
+use App\Controller\TaskFormController;
+use App\Entity\Onboarding;
+use App\Entity\OnboardingTask;
+use App\Entity\Role;
+use App\Service\OnboardingTaskFacade;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\EntityRepository;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpFoundation\Response;
+
+class TaskFormControllerTest extends TestCase
+{
+    public function testAddThrowsWhenOnboardingMissing(): void
+    {
+        $repo = $this->createMock(EntityRepository::class);
+        $repo->method('find')->willReturn(null);
+
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->method('getRepository')->willReturn($repo);
+
+        $facade = $this->createMock(OnboardingTaskFacade::class);
+
+        $controller = new TaskFormController($facade);
+
+        $this->expectException(NotFoundHttpException::class);
+        $controller->add(1, new Request(), $em);
+    }
+
+    public function testAddRendersForm(): void
+    {
+        $onboarding = new Onboarding();
+        $repo = $this->createMock(EntityRepository::class);
+        $repo->method('find')->willReturn($onboarding);
+
+        $roleRepo = $this->createMock(EntityRepository::class);
+        $roleRepo->method('findAll')->willReturn([]);
+
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->method('getRepository')->willReturnMap([
+            [Onboarding::class, $repo],
+            [Role::class, $roleRepo],
+        ]);
+
+        $facade = $this->createMock(OnboardingTaskFacade::class);
+
+        $controller = new class($facade) extends TaskFormController {
+            public array $args;
+            protected function render(string $view, array $parameters = [], ?Response $response = null): Response
+            {
+                $this->args = ['view' => $view, 'params' => $parameters];
+                return new Response();
+            }
+        };
+
+        $response = $controller->add(1, new Request(), $em);
+
+        $this->assertSame('dashboard/onboarding_task_form.html.twig', $controller->args['view']);
+        $this->assertSame(['onboarding' => $onboarding, 'roles' => [], 'task' => null], $controller->args['params']);
+        $this->assertInstanceOf(Response::class, $response);
+    }
+}


### PR DESCRIPTION
## Summary
- add missing unit tests for various controllers

## Testing
- `vendor/bin/phpunit` *(fails: EncryptSmtpPasswordsCommandTest and UserControllerTest assertions fail)*

------
https://chatgpt.com/codex/tasks/task_e_68861ed651188331957652ef1a24513e